### PR TITLE
Adds Preconditions feature w/ example

### DIFF
--- a/MINA_COMMIT
+++ b/MINA_COMMIT
@@ -1,2 +1,2 @@
 The mina commit used to generate the backends for node and chrome is
-a1529d0ed3a8bcf2a84e06fe71a7b78244fc0b5c
+2830249951ba96947460a6e4872ffb78aaf2b31b

--- a/src/examples/fetch.ts
+++ b/src/examples/fetch.ts
@@ -1,4 +1,10 @@
-import { fetchAccount, isReady, setGraphqlEndpoint, shutdown } from 'snarkyjs';
+import {
+  fetchAccount,
+  isReady,
+  setGraphqlEndpoint,
+  shutdown,
+  fetchLastBlock,
+} from 'snarkyjs';
 
 await isReady;
 setGraphqlEndpoint('https://proxy.berkeley.minaexplorer.com/graphql');
@@ -7,5 +13,8 @@ let zkappAddress = 'B62qpRzFVjd56FiHnNfxokVbcHMQLT119My1FEdSq8ss7KomLiSZcan';
 let { account, error } = await fetchAccount(zkappAddress);
 console.log('account', JSON.stringify(account, null, 2));
 console.log('error', error);
+
+let block = await fetchLastBlock();
+console.log('last block', JSON.stringify(block, null, 2));
 
 await shutdown();

--- a/src/examples/simple_zkapp.mjs
+++ b/src/examples/simple_zkapp.mjs
@@ -42,7 +42,7 @@ let initialState = Field(1);
 let zkapp = new SimpleZkapp(zkappAddress);
 
 console.log('compile');
-SimpleZkapp.compile(zkappAddress);
+await SimpleZkapp.compile(zkappAddress);
 
 console.log('deploy');
 let tx = await Mina.transaction(feePayerKey, () => {

--- a/src/examples/simple_zkapp.ts
+++ b/src/examples/simple_zkapp.ts
@@ -11,6 +11,8 @@ import {
   isReady,
   Permissions,
   DeployArgs,
+  UInt32,
+  Bool,
 } from 'snarkyjs';
 
 await isReady;
@@ -29,43 +31,102 @@ class SimpleZkapp extends SmartContract {
   }
 
   @method update(y: Field) {
-    // update is only valid if the balance is at least 10 MINA
-    Party.assertBetween(
-      this.self.body.accountPrecondition.balance,
-      UInt64.fromNumber(10e9),
-      UInt64.MAXINT()
-    );
     let x = this.x.get();
     this.x.set(x.add(y));
+  }
+
+  /**
+   * This method allows a certain privileged account to claim half of the zkapp balance, but only once
+   * @param caller the privileged account
+   */
+  @method payout(caller: PrivateKey) {
+    // check that caller is the privileged account
+    let callerAddress = caller.toPublicKey();
+    callerAddress.assertEquals(privilegedAddress);
+
+    // assert that the caller nonce is 0, and increment the nonce - this way, payout can only happen once
+    let callerParty = Party.createUnsigned(callerAddress);
+    callerParty.account.nonce.assertEquals(UInt32.zero);
+    callerParty.body.incrementNonce = Bool.true;
+
+    // pay out half of the zkapp balance to the caller
+    let balance = this.account.balance.get();
+    this.account.balance.assertEquals(balance);
+    let halfBalance = balance.div(2);
+    this.balance.subInPlace(halfBalance);
+    callerParty.balance.addInPlace(halfBalance);
   }
 }
 
 let Local = Mina.LocalBlockchain();
 Mina.setActiveInstance(Local);
 
-let account1 = Local.testAccounts[0].privateKey;
+// a test account that pays all the fees, and puts additional funds into the zkapp
+let feePayer = Local.testAccounts[0].privateKey;
 
+// the zkapp account
 let zkappKey = PrivateKey.random();
 let zkappAddress = zkappKey.toPublicKey();
+
+// a special account that is allowed to pull out half of the zkapp balance, once
+let privilegedKey = Local.testAccounts[1].privateKey;
+let privilegedAddress = privilegedKey.toPublicKey();
 
 let initialBalance = 10_000_000_000;
 let initialState = Field(1);
 let zkapp = new SimpleZkapp(zkappAddress);
 
 console.log('deploy');
-let tx = await Local.transaction(account1, () => {
-  Party.fundNewAccount(account1, { initialBalance });
+let tx = await Local.transaction(feePayer, () => {
+  Party.fundNewAccount(feePayer, { initialBalance });
   zkapp.deploy({ zkappKey });
 });
 tx.send();
 
 console.log('initial state: ' + zkapp.x.get());
+console.log(`initial balance: ${zkapp.account.balance.get().div(1e9)} MINA`);
 
 console.log('update');
-tx = await Local.transaction(account1, () => {
+tx = await Local.transaction(feePayer, () => {
   zkapp.update(Field(3));
   zkapp.sign(zkappKey);
 });
 tx.send();
 
+console.log('payout');
+tx = await Local.transaction(feePayer, () => {
+  zkapp.payout(privilegedKey);
+  zkapp.sign(zkappKey);
+});
+tx.send();
+
 console.log('final state: ' + zkapp.x.get());
+console.log(`final balance: ${zkapp.account.balance.get().div(1e9)} MINA`);
+
+console.log('try to payout a second time..');
+tx = await Local.transaction(feePayer, () => {
+  zkapp.payout(privilegedKey);
+  zkapp.sign(zkappKey);
+});
+try {
+  tx.send();
+} catch (err: any) {
+  console.log('Transaction failed with error', err.message);
+}
+
+console.log('try to payout to a different account..');
+try {
+  tx = await Local.transaction(feePayer, () => {
+    zkapp.payout(Local.testAccounts[2].privateKey);
+    zkapp.sign(zkappKey);
+  });
+  tx.send();
+} catch (err: any) {
+  console.log('Transaction failed with error', err.message);
+}
+
+console.log(
+  `should still be the same final balance: ${zkapp.account.balance
+    .get()
+    .div(1e9)} MINA`
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,12 @@ export * from './lib/circuit_value';
 export * from './lib/int';
 export * as Mina from './lib/mina';
 export * from './lib/zkapp';
+export { state, State, declareState } from './lib/state';
 // export * from './lib/proof_system';
 export * from './lib/party';
 export {
   fetchAccount,
+  fetchLastBlock,
   parseFetchedAccount,
   addCachedAccount,
   setGraphqlEndpoint,

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,15 +1,20 @@
 import 'isomorphic-fetch';
-import { Field, Types } from '../snarky';
+import { Bool, Field, Types } from '../snarky';
 import { UInt32, UInt64 } from './int';
 import { Permission, Permissions, ZkappStateLength } from './party';
 import { PublicKey } from './signature';
+import { NetworkValue } from './precondition';
 
 export {
   fetchAccount,
+  fetchLastBlock,
+  fetchBlock,
   parseFetchedAccount,
   markAccountToBeFetched,
-  fetchMissingAccounts,
+  markNetworkToBeFetched,
+  fetchMissingData,
   getCachedAccount,
+  getCachedNetwork,
   addCachedAccount,
   defaultGraphqlEndpoint,
   setGraphqlEndpoint,
@@ -121,7 +126,7 @@ type FetchedAccount = {
   nonce: string;
   zkappUri?: string;
   zkappState: string[] | null;
-  receiptChainState?: string;
+  receiptChainHash?: string;
   balance: { total: string };
   permissions?: {
     editState: AuthRequired;
@@ -136,6 +141,9 @@ type FetchedAccount = {
     incrementNonce: AuthRequired;
     setVotingFor: AuthRequired;
   };
+  delegateAccount?: { publicKey: string };
+  sequenceEvents?: string[] | null;
+  // TODO: how to query provedState?
 };
 
 type Account = {
@@ -144,6 +152,10 @@ type Account = {
   balance: UInt64;
   zkapp?: { appState: Field[] };
   permissions?: Permissions;
+  receiptChainHash?: Field;
+  delegate?: PublicKey;
+  sequenceState?: Field;
+  provedState?: Bool;
 };
 
 type FlexibleAccount = {
@@ -153,7 +165,7 @@ type FlexibleAccount = {
   zkapp?: { appState: (Field | string | number)[] };
 };
 
-// TODO add more fields
+// TODO provedState
 const accountQuery = (publicKey: string) => `{
   account(publicKey: "${publicKey}") {
     publicKey
@@ -175,6 +187,8 @@ const accountQuery = (publicKey: string) => `{
     }
     receiptChainHash
     balance { total }
+    delegateAccount { publicKey }
+    sequenceEvents
   }
 }
 `;
@@ -190,6 +204,9 @@ function parseFetchedAccount({
   zkappState,
   balance,
   permissions,
+  delegateAccount,
+  receiptChainHash,
+  sequenceEvents,
 }: Partial<FetchedAccount>): Partial<Account> {
   return {
     publicKey:
@@ -202,6 +219,16 @@ function parseFetchedAccount({
       (Object.fromEntries(
         Object.entries(permissions).map(([k, v]) => [k, toPermission(v)])
       ) as unknown as Permissions),
+    // TODO: how is sequenceState related to sequenceEvents?
+    sequenceState:
+      sequenceEvents != undefined ? Field(sequenceEvents[0]) : undefined,
+    // TODO: how to parse receptChainHash?
+    // receiptChainHash:
+    //   receiptChainHash !== undefined
+    //     ? Ledger.fieldOfBase58(receiptChainHash)
+    //     : undefined,
+    delegate:
+      delegateAccount && PublicKey.fromBase58(delegateAccount.publicKey),
   };
 }
 
@@ -218,34 +245,6 @@ function stringifyAccount(account: FlexibleAccount): FetchedAccount {
   };
 }
 
-async function checkResponseStatus(
-  response: Response
-): Promise<[FetchResponse, undefined] | [undefined, FetchError]> {
-  if (response.ok) {
-    return [(await response.json()) as FetchResponse, undefined];
-  } else {
-    return [
-      undefined,
-      {
-        statusCode: response.status,
-        statusText: response.statusText,
-      } as FetchError,
-    ];
-  }
-}
-
-function inferError(error: unknown): FetchError {
-  let errorMessage = JSON.stringify(error);
-  if (error instanceof AbortSignal) {
-    return { statusCode: 408, statusText: `Request Timeout: ${errorMessage}` };
-  } else {
-    return {
-      statusCode: 500,
-      statusText: `Unknown Error: ${errorMessage}`,
-    };
-  }
-}
-
 let accountCache = {} as Record<
   string,
   {
@@ -254,10 +253,19 @@ let accountCache = {} as Record<
     timestamp: number;
   }
 >;
+let networkCache = {} as Record<
+  string,
+  {
+    network: NetworkValue;
+    graphqlEndpoint: string;
+    timestamp: number;
+  }
+>;
 let accountsToFetch = {} as Record<
   string,
   { publicKey: string; graphqlEndpoint: string }
 >;
+let networksToFetch = {} as Record<string, { graphqlEndpoint: string }>;
 let cacheExpiry = 10 * 60 * 1000; // 10 minutes
 
 function markAccountToBeFetched(publicKey: PublicKey, graphqlEndpoint: string) {
@@ -267,20 +275,39 @@ function markAccountToBeFetched(publicKey: PublicKey, graphqlEndpoint: string) {
     graphqlEndpoint,
   };
 }
+function markNetworkToBeFetched(graphqlEndpoint: string) {
+  networksToFetch[graphqlEndpoint] = { graphqlEndpoint };
+}
 
-async function fetchMissingAccounts(graphqlEndpoint: string) {
+async function fetchMissingData(graphqlEndpoint: string) {
   let expired = Date.now() - cacheExpiry;
   let accounts = Object.entries(accountsToFetch).filter(([key, account]) => {
     if (account.graphqlEndpoint !== graphqlEndpoint) return false;
     let cachedAccount = accountCache[key];
     return cachedAccount === undefined || cachedAccount.timestamp < expired;
   });
-  await Promise.all(
-    accounts.map(async ([key, { publicKey }]) => {
-      let response = await fetchAccountInternal(publicKey, graphqlEndpoint);
-      if (response.error === undefined) delete accountsToFetch[key];
-    })
-  );
+  let promises = accounts.map(async ([key, { publicKey }]) => {
+    let response = await fetchAccountInternal(publicKey, graphqlEndpoint);
+    if (response.error === undefined) delete accountsToFetch[key];
+  });
+
+  let network = Object.entries(networksToFetch).find(([key, network]) => {
+    if (network.graphqlEndpoint !== graphqlEndpoint) return;
+    let cachedNetwork = networkCache[key];
+    return cachedNetwork === undefined || cachedNetwork.timestamp < expired;
+  });
+  if (network !== undefined) {
+    promises.push(
+      (async () => {
+        try {
+          await fetchLastBlock(graphqlEndpoint);
+          delete networksToFetch[network[0]];
+        } catch {}
+      })()
+    );
+  }
+
+  await Promise.all(promises);
 }
 
 function getCachedAccount(
@@ -290,6 +317,9 @@ function getCachedAccount(
   let account =
     accountCache[`${publicKey.toBase58()};${graphqlEndpoint}`]?.account;
   if (account !== undefined) return parseFetchedAccount(account);
+}
+function getCachedNetwork(graphqlEndpoint = defaultGraphqlEndpoint) {
+  return networkCache[graphqlEndpoint]?.network;
 }
 
 function addCachedAccount(
@@ -314,6 +344,163 @@ function addCachedAccountInternal(
     account,
     graphqlEndpoint,
     timestamp: Date.now(),
+  };
+}
+
+async function fetchLastBlock(graphqlEndpoint = defaultGraphqlEndpoint) {
+  let bestChainQuery = `{ bestChain { protocolState { consensusState { blockHeight } } } }`;
+  let [resp, error] = await makeGraphqlRequest(bestChainQuery, graphqlEndpoint);
+  if (error) throw Error(error.statusText);
+  let blockHeights = resp?.data.bestChain.map(
+    (block: FetchedBlock) => block.protocolState.consensusState.blockHeight
+  );
+  let lastHeight = blockHeights[blockHeights.length - 1];
+  let network = await fetchBlock(lastHeight);
+  networkCache[graphqlEndpoint] = {
+    network,
+    graphqlEndpoint,
+    timestamp: Date.now(),
+  };
+  return network;
+}
+
+async function fetchBlock(
+  blockHeight: number,
+  graphqlEndpoint = defaultGraphqlEndpoint
+) {
+  let [resp, error] = await makeGraphqlRequest(
+    blockQuery(blockHeight),
+    graphqlEndpoint
+  );
+  if (error) throw Error(error.statusText);
+  return parseFetchedBlock(resp?.data?.block as FetchedBlock);
+}
+
+const blockQuery = (height: number) => `{
+  block(height: ${height}) {
+    protocolState {
+      blockchainState {
+        snarkedLedgerHash
+        stagedLedgerHash
+        date
+        utcDate
+        stagedLedgerProofEmitted
+      }
+      previousStateHash
+      consensusState {
+        blockHeight
+        slotSinceGenesis
+        slot
+        nextEpochData {
+          ledger {hash totalCurrency}
+          seed
+          startCheckpoint
+          lockCheckpoint
+          epochLength
+        }
+        stakingEpochData {
+          ledger {hash totalCurrency}
+          seed
+          startCheckpoint
+          lockCheckpoint
+          epochLength
+        }
+        epochCount
+        minWindowDensity
+        totalCurrency
+        epoch
+      }
+    }
+  }
+}`;
+
+type FetchedBlock = {
+  protocolState: {
+    blockchainState: {
+      snarkedLedgerHash: string; // hash-like encoding
+      stagedLedgerHash: string; // hash-like encoding
+      date: string; // String(Date.now())
+      utcDate: string; // String(Date.now())
+      stagedLedgerProofEmitted: boolean; // bool
+    };
+    previousStateHash: string; // hash-like encoding
+    consensusState: {
+      blockHeight: string; // String(number)
+      slotSinceGenesis: string; // String(number)
+      slot: string; // String(number)
+      nextEpochData: {
+        ledger: {
+          hash: string; // hash-like encoding
+          totalCurrency: string; // String(number)
+        };
+        seed: string; // hash-like encoding
+        startCheckpoint: string; // hash-like encoding
+        lockCheckpoint: string; // hash-like encoding
+        epochLength: string; // String(number)
+      };
+      stakingEpochData: {
+        ledger: {
+          hash: string; // hash-like encoding
+          totalCurrency: string; // String(number)
+        };
+        seed: string; // hash-like encoding
+        startCheckpoint: string; // hash-like encoding
+        lockCheckpoint: string; // hash-like encoding
+        epochLength: string; // String(number)
+      };
+      epochCount: string; // String(number)
+      minWindowDensity: string; // String(number)
+      totalCurrency: string; // String(number)
+      epoch: string; // String(number)
+    };
+  };
+};
+
+function parseFetchedBlock({
+  protocolState: {
+    blockchainState: { snarkedLedgerHash, utcDate },
+    consensusState: {
+      blockHeight,
+      minWindowDensity,
+      totalCurrency,
+      slot,
+      slotSinceGenesis,
+      nextEpochData,
+      stakingEpochData,
+    },
+  },
+}: FetchedBlock): NetworkValue {
+  return {
+    snarkedLedgerHash: Field.zero, // TODO
+    // TODO: use date or utcDate?
+    timestamp: UInt64.fromString(utcDate),
+    blockchainLength: UInt32.fromString(blockHeight),
+    minWindowDensity: UInt32.fromString(minWindowDensity),
+    totalCurrency: UInt64.fromString(totalCurrency),
+    // is this really `slot`?
+    globalSlotSinceHardFork: UInt32.fromString(slot),
+    globalSlotSinceGenesis: UInt32.fromString(slotSinceGenesis),
+    nextEpochData: parseEpochData(nextEpochData),
+    stakingEpochData: parseEpochData(stakingEpochData),
+  };
+}
+
+function parseEpochData({
+  ledger: { hash, totalCurrency },
+  seed,
+  startCheckpoint,
+  lockCheckpoint,
+  epochLength,
+}: FetchedBlock['protocolState']['consensusState']['nextEpochData']): NetworkValue['nextEpochData'] {
+  return {
+    ledger: {
+      hash: Field.zero, // TODO
+      totalCurrency: UInt64.fromString(totalCurrency),
+    },
+    seed: Field.zero, // TODO
+    startCheckpoint: Field.zero, // TODO
+    lockCheckpoint: Field.zero, // TODO
+    epochLength: UInt32.fromString(epochLength),
   };
 }
 
@@ -378,5 +565,33 @@ async function makeGraphqlRequest(
   } catch (error) {
     clearTimeout(timer);
     return [undefined, inferError(error)] as [undefined, FetchError];
+  }
+}
+
+async function checkResponseStatus(
+  response: Response
+): Promise<[FetchResponse, undefined] | [undefined, FetchError]> {
+  if (response.ok) {
+    return [(await response.json()) as FetchResponse, undefined];
+  } else {
+    return [
+      undefined,
+      {
+        statusCode: response.status,
+        statusText: response.statusText,
+      } as FetchError,
+    ];
+  }
+}
+
+function inferError(error: unknown): FetchError {
+  let errorMessage = JSON.stringify(error);
+  if (error instanceof AbortSignal) {
+    return { statusCode: 408, statusText: `Request Timeout: ${errorMessage}` };
+  } else {
+    return {
+      statusCode: 500,
+      statusText: `Unknown Error: ${errorMessage}`,
+    };
   }
 }

--- a/src/lib/global-context.ts
+++ b/src/lib/global-context.ts
@@ -1,15 +1,76 @@
-import { Party } from './party';
+import * as Mina from './mina';
+import { Body, Party } from './party';
+import { PublicKey } from './signature';
+import { SmartContract } from './zkapp';
 
 export {
+  selfParty,
+  getExecutionState,
   withContext,
   withContextAsync,
   getContext,
-  mainContext,
   inProver,
   inCompile,
   inCheckedComputation,
 };
 
+// per-smart-contract context for transaction construction
+type ExecutionState = {
+  transactionId: number;
+  partyIndex: number;
+  party: Party;
+};
+
+function selfParty(address: PublicKey) {
+  let body = Body.keepAll(address);
+  return new (Party as any)(body, {}, true) as Party;
+}
+
+function getExecutionState(smartContract: SmartContract): ExecutionState {
+  // TODO reconcile mainContext with currentTransaction
+  if (mainContext !== undefined) {
+    return {
+      transactionId: 0,
+      partyIndex: 0,
+      party: mainContext.self,
+    };
+  }
+
+  if (Mina.currentTransaction === undefined) {
+    // throw new Error('Cannot execute outside of a Mina.transaction() block.');
+    // TODO: it's inefficient to return a fresh party everytime, would be better to return a constant "non-writable" party,
+    // or even expose the .get() methods independently of any party (they don't need one)
+    return {
+      transactionId: NaN,
+      partyIndex: NaN,
+      party: selfParty(smartContract.address),
+    };
+  }
+
+  let executionState = executionStates.get(smartContract);
+  if (
+    executionState !== undefined &&
+    executionState.transactionId === Mina.nextTransactionId.value
+  ) {
+    return executionState;
+  }
+  let id = Mina.nextTransactionId.value;
+  let index = Mina.currentTransaction.nextPartyIndex++;
+  let party = selfParty(smartContract.address);
+  Mina.currentTransaction.parties.push(party);
+
+  executionState = {
+    transactionId: id,
+    partyIndex: index,
+    party,
+  };
+  executionStates.set(smartContract, executionState);
+  return executionState;
+}
+
+const executionStates = new WeakMap<SmartContract, ExecutionState>();
+
+// context for compiling / proving
 // TODO reconcile mainContext with currentTransaction
 let mainContext = undefined as
   | {

--- a/src/lib/int.ts
+++ b/src/lib/int.ts
@@ -1,15 +1,18 @@
-import { Circuit, Field } from '../snarky';
+import { Circuit, Field, Types } from '../snarky';
 import { CircuitValue, prop } from './circuit_value';
 
 export { UInt32, UInt64, Int64 };
 
-class UInt64 extends CircuitValue {
+class UInt64 extends CircuitValue implements Types.UInt64 {
   @prop value: Field;
   static NUM_BITS = 64;
+  type = 'UInt64' as const;
 
   constructor(value: Field) {
     super();
     this.value = value;
+    // TODO type breaks Circuit.if for some reason
+    delete (this as any).type;
   }
 
   static get zero() {
@@ -24,7 +27,7 @@ class UInt64 extends CircuitValue {
     return this.value.toString();
   }
 
-  static check(x: UInt64) {
+  static check(x: Types.UInt64) {
     let actual = x.value.rangeCheckHelper(64);
     actual.assertEquals(x.value);
   }
@@ -176,13 +179,16 @@ class UInt64 extends CircuitValue {
   }
 }
 
-class UInt32 extends CircuitValue {
+class UInt32 extends CircuitValue implements Types.UInt32 {
   @prop value: Field;
   static NUM_BITS = 32;
+  type = 'UInt32' as const;
 
   constructor(value: Field) {
     super();
     this.value = value;
+    // TODO type breaks Circuit.if for some reason
+    delete (this as any).type;
   }
 
   static get zero(): UInt32 {
@@ -202,7 +208,7 @@ class UInt32 extends CircuitValue {
     return new UInt64(this.value);
   }
 
-  static check(x: UInt32) {
+  static check(x: Types.UInt32) {
     let actual = x.value.rangeCheckHelper(32);
     actual.assertEquals(x.value);
   }
@@ -332,7 +338,9 @@ class UInt32 extends CircuitValue {
   }
 }
 
-class Int64 extends CircuitValue {
+type BalanceChange = Types.Party['body']['balanceChange'];
+
+class Int64 extends CircuitValue implements BalanceChange {
   // * in the range [-2^64+1, 2^64-1], unlike a normal int64
   // * under- and overflowing is disallowed, similar to UInt64, unlike a normal int64+
 

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -13,6 +13,8 @@ import {
   ZkappStateLength,
 } from './party';
 import * as Fetch from './fetch';
+import { assertPreconditionInvariants, NetworkValue } from './precondition';
+import { cloneCircuitValue } from './circuit_value';
 
 export {
   createUnsignedTransaction,
@@ -27,6 +29,7 @@ export {
   currentSlot,
   getAccount,
   getBalance,
+  getNetworkState,
   accountCreationFee,
   sendTransaction,
 };
@@ -39,7 +42,7 @@ interface Transaction {
   transaction: Parties;
   toJSON(): string;
   toGraphqlQuery(): string;
-  sign(): Transaction;
+  sign(additionialKeys?: PrivateKey[]): Transaction;
   prove(): Promise<Transaction>;
   send(): TransactionId;
 }
@@ -104,6 +107,10 @@ function createTransaction(
     // TODO would be nice if the error would be a bit more descriptive about what failed
     throw err;
   }
+  // assert invariants on the created parties
+  for (let party of currentTransaction.parties) {
+    assertPreconditionInvariants(party);
+  }
 
   let feePayerParty: FeePayerUnsigned;
   if (feePayerKey !== undefined) {
@@ -164,7 +171,8 @@ interface Mina {
   transaction(sender: SenderSpec, f: () => void): Promise<Transaction>;
   currentSlot(): UInt32;
   getAccount(publicKey: Types.PublicKey): Account;
-  accountCreationFee(): UInt32;
+  getNetworkState(): NetworkValue;
+  accountCreationFee(): UInt64;
   sendTransaction(transaction: Transaction): TransactionId;
 }
 interface MockMina extends Mina {
@@ -185,7 +193,6 @@ const defaultAccountCreationFee = 1_000_000_000;
 function LocalBlockchain({
   accountCreationFee = defaultAccountCreationFee as string | number,
 } = {}): MockMina {
-  let accountCreationFee_ = String(accountCreationFee);
   const msPerSlot = 3 * 60 * 1000;
   const startTime = new Date().valueOf();
 
@@ -205,7 +212,7 @@ function LocalBlockchain({
   }
 
   return {
-    accountCreationFee: () => UInt32.fromString(accountCreationFee_),
+    accountCreationFee: () => UInt64.from(accountCreationFee),
     currentSlot() {
       return UInt32.fromNumber(
         Math.ceil((new Date().valueOf() - startTime) / msPerSlot)
@@ -226,11 +233,18 @@ function LocalBlockchain({
         };
       }
     },
+    getNetworkState() {
+      // TODO:
+      // * enable to change the network state, to test various preconditions
+      // * pass the network state to be used to applyJsonTransaction (needs JS -> OCaml transfer)
+      // * could make totalCurrency consistent with the sum of account balances
+      return dummyNetworkState();
+    },
     sendTransaction(txn: Transaction) {
       txn.sign();
       ledger.applyJsonTransaction(
         JSON.stringify(partiesToJson(txn.transaction)),
-        accountCreationFee_
+        String(accountCreationFee)
       );
       return { wait: async () => {} };
     },
@@ -238,7 +252,7 @@ function LocalBlockchain({
       return createTransaction(sender, f);
     },
     applyJsonTransaction(json: string) {
-      return ledger.applyJsonTransaction(json, accountCreationFee_);
+      return ledger.applyJsonTransaction(json, String(accountCreationFee));
     },
     addAccount,
     testAccounts,
@@ -246,7 +260,7 @@ function LocalBlockchain({
 }
 
 function RemoteBlockchain(graphqlEndpoint: string): Mina {
-  let accountCreationFee = UInt32.fromNumber(defaultAccountCreationFee);
+  let accountCreationFee = UInt64.from(defaultAccountCreationFee);
   Fetch.setGraphqlEndpoint(graphqlEndpoint);
   return {
     accountCreationFee: () => accountCreationFee,
@@ -272,26 +286,50 @@ function RemoteBlockchain(graphqlEndpoint: string): Mina {
         `getAccount: Could not find account for public key ${publicKey.toBase58()}.\nGraphql endpoint: ${graphqlEndpoint}`
       );
     },
+    getNetworkState() {
+      if (currentTransaction?.fetchMode === 'test') {
+        Fetch.markNetworkToBeFetched(graphqlEndpoint);
+        let network = Fetch.getCachedNetwork(graphqlEndpoint);
+        return network ?? dummyNetworkState();
+      }
+      if (
+        currentTransaction == undefined ||
+        currentTransaction.fetchMode === 'cached'
+      ) {
+        let network = Fetch.getCachedNetwork(graphqlEndpoint);
+        if (network !== undefined) return network;
+      }
+      throw Error(
+        `getNetworkState: Could not fetch network state from graphql endpoint ${graphqlEndpoint}`
+      );
+    },
     sendTransaction(txn: Transaction) {
       txn.sign();
       let sendPromise = Fetch.sendZkapp(txn.toJSON());
       return {
         async wait() {
           let [response, error] = await sendPromise;
-          console.log('got graphql response', { response, error });
-          console.log(
-            'Info: waiting for inclusion in a block is not implemented yet.'
-          );
-          // if (error !== undefined) {
-          //   console.log('Graphql transaction failed. Query:');
-          //   console.log(txn.toGraphqlQuery());
-          // }
+          if (error === undefined) {
+            if (
+              response!.data === null &&
+              (response as any).errors?.length > 0
+            ) {
+              console.log('got graphql errors', (response as any).errors);
+            } else {
+              console.log('got graphql response', response);
+              console.log(
+                'Info: waiting for inclusion in a block is not implemented yet.'
+              );
+            }
+          } else {
+            console.log('got fetch error', error);
+          }
         },
       };
     },
     async transaction(sender: SenderSpec, f: () => void) {
       createTransaction(sender, f, { fetchMode: 'test' });
-      await Fetch.fetchMissingAccounts(graphqlEndpoint);
+      await Fetch.fetchMissingData(graphqlEndpoint);
       return createTransaction(sender, f, { fetchMode: 'cached' });
     },
   };
@@ -302,7 +340,7 @@ function BerkeleyQANet(graphqlEndpoint: string) {
 }
 
 let activeInstance: Mina = {
-  accountCreationFee: () => UInt32.fromNumber(defaultAccountCreationFee),
+  accountCreationFee: () => UInt64.from(defaultAccountCreationFee),
   currentSlot: () => {
     throw new Error('must call Mina.setActiveInstance first');
   },
@@ -325,6 +363,9 @@ let activeInstance: Mina = {
         );
       return account;
     }
+    throw new Error('must call Mina.setActiveInstance first');
+  },
+  getNetworkState() {
     throw new Error('must call Mina.setActiveInstance first');
   },
   sendTransaction() {
@@ -388,6 +429,13 @@ function getAccount(pubkey: Types.PublicKey) {
 }
 
 /**
+ * @return Data associated with the current state of the Mina network.
+ */
+function getNetworkState() {
+  return activeInstance.getNetworkState();
+}
+
+/**
  * @return The balance associated to the given public key.
  */
 function getBalance(pubkey: Types.PublicKey) {
@@ -408,5 +456,26 @@ function dummyAccount(pubkey?: PublicKey): Account {
     nonce: UInt32.zero,
     publicKey: pubkey ?? PublicKey.empty(),
     zkapp: { appState: Array(ZkappStateLength).fill(Field.zero) },
+  };
+}
+
+function dummyNetworkState(): NetworkValue {
+  let epochData: NetworkValue['stakingEpochData'] = {
+    ledger: { hash: Field.zero, totalCurrency: UInt64.zero },
+    seed: Field.zero,
+    startCheckpoint: Field.zero,
+    lockCheckpoint: Field.zero,
+    epochLength: UInt32.zero,
+  };
+  return {
+    snarkedLedgerHash: Field.zero,
+    timestamp: UInt64.zero,
+    blockchainLength: UInt32.zero,
+    minWindowDensity: UInt32.zero,
+    totalCurrency: UInt64.zero,
+    globalSlotSinceHardFork: UInt32.zero,
+    globalSlotSinceGenesis: UInt32.zero,
+    stakingEpochData: epochData,
+    nextEpochData: cloneCircuitValue(epochData),
   };
 }

--- a/src/lib/party.ts
+++ b/src/lib/party.ts
@@ -5,11 +5,13 @@ import { UInt64, UInt32, Int64 } from './int';
 import * as Mina from './mina';
 import { SmartContract } from './zkapp';
 import { withContextAsync } from './global-context';
+import * as Precondition from './precondition';
 
 export {
   SetOrKeep,
   Permission,
   Permissions,
+  Preconditions,
   Body,
   Party,
   FeePayerUnsigned,
@@ -30,6 +32,11 @@ const ZkappStateLength = 8;
 
 type PartyBody = Types.Party['body'];
 type Update = PartyBody['update'];
+
+/**
+ * Preconditions for the network and accounts
+ */
+type Preconditions = PartyBody['preconditions'];
 
 /**
  * Timing info inside an account.
@@ -219,7 +226,7 @@ let Permissions = {
   }),
 };
 
-export const getDefaultTokenId = () => Field.one;
+const getDefaultTokenId = () => Field.one;
 
 // TODO
 class Events {
@@ -284,8 +291,7 @@ interface Body extends PartyBody {
   caller: Field;
   callData: Field; //MerkleList<Array<Field>>;
   callDepth: number; // TODO: this is an `int As_prover.t`
-  protocolStatePrecondition: ProtocolStatePrecondition;
-  accountPrecondition: AccountPrecondition;
+  preconditions: Preconditions;
   useFullCommitment: Bool;
   incrementNonce: Bool;
 }
@@ -333,8 +339,7 @@ const Body = {
       caller: getDefaultTokenId(),
       callData: Field.zero, // TODO new MerkleList(),
       callDepth: 0,
-      protocolStatePrecondition: ProtocolStatePrecondition.ignoreAll(),
-      accountPrecondition: AccountPrecondition.ignoreAll(),
+      preconditions: Preconditions.ignoreAll(),
       // the default assumption is that snarkyjs transactions don't include the fee payer
       // so useFullCommitment has to be false for signatures to be correct
       useFullCommitment: Bool(false),
@@ -359,7 +364,7 @@ const FeePayerBody = {
       update: Body.noUpdate(),
       events: Events.empty(),
       sequenceEvents: Events.empty(),
-      protocolStatePrecondition: ProtocolStatePrecondition.ignoreAll(),
+      networkPrecondition: NetworkPrecondition.ignoreAll(),
     };
   },
 };
@@ -384,9 +389,9 @@ type OrIgnore<T> = { isSome: Bool; value: T };
  */
 type ClosedInterval<T> = { lower: T; upper: T };
 
-type ProtocolStatePrecondition = PartyBody['protocolStatePrecondition'];
-let ProtocolStatePrecondition = {
-  ignoreAll(): ProtocolStatePrecondition {
+type NetworkPrecondition = Preconditions['network'];
+let NetworkPrecondition = {
+  ignoreAll(): NetworkPrecondition {
     let stakingEpochData = {
       ledger: { hash: ignore(Field.zero), totalCurrency: uint64() },
       seed: ignore(Field.zero),
@@ -429,8 +434,8 @@ const uint32 = () => ({ lower: UInt32.fromNumber(0), upper: UInt32.MAXINT() });
  */
 const uint64 = () => ({ lower: UInt64.fromNumber(0), upper: UInt64.MAXINT() });
 
-export type AccountPrecondition = PartyBody['accountPrecondition'];
-export const AccountPrecondition = {
+type AccountPrecondition = Preconditions['account'];
+const AccountPrecondition = {
   ignoreAll(): AccountPrecondition {
     let appState: Array<OrIgnore<Field>> = [];
     for (let i = 0; i < ZkappStateLength; ++i) {
@@ -453,6 +458,15 @@ export const AccountPrecondition = {
   },
 };
 
+const Preconditions = {
+  ignoreAll(): Preconditions {
+    return {
+      account: AccountPrecondition.ignoreAll(),
+      network: NetworkPrecondition.ignoreAll(),
+    };
+  },
+};
+
 type Control = Types.Party['authorization'];
 
 type LazySignature = { kind: 'lazy-signature'; privateKey?: PrivateKey };
@@ -469,10 +483,26 @@ type LazyControl = Control | LazySignature | LazyProof;
 
 class Party {
   body: Body;
-  authorization: LazyControl = {};
+  authorization: LazyControl;
+  account: Precondition.Account;
+  network: Precondition.Network;
 
-  constructor(body: Body) {
+  private isSelf: boolean;
+
+  constructor(body: Body, authorization?: LazyControl);
+  constructor(body: Body, authorization = {} as LazyControl, isSelf = false) {
     this.body = body;
+    this.authorization = authorization;
+    let { account, network } = Precondition.preconditions(this, isSelf);
+    this.account = account;
+    this.network = network;
+    this.isSelf = isSelf;
+  }
+
+  static clone(party: Party) {
+    let body = cloneCircuitValue(party.body);
+    let authorization = cloneCircuitValue(party.authorization);
+    return new (Party as any)(body, authorization, party.isSelf);
   }
 
   get balance() {
@@ -557,7 +587,7 @@ class Party {
   }
 
   sign(privateKey?: PrivateKey) {
-    let party = cloneCircuitValue(this);
+    let party = Party.clone(this);
     party.signInPlace(privateKey);
     return party;
   }
@@ -595,7 +625,7 @@ class Party {
 
   setNoncePrecondition(fallbackToZero = false) {
     let nonce = Party.getNonce(this, fallbackToZero);
-    let accountPrecondition = this.body.accountPrecondition;
+    let accountPrecondition = this.body.preconditions.account;
     Party.assertEquals(accountPrecondition.nonce, nonce);
     return nonce;
   }
@@ -691,7 +721,7 @@ class Party {
       nonceIncrement.add(new UInt32(shouldIncreaseNonce.toField()));
     }
     nonce = nonce.add(nonceIncrement);
-    Party.assertEquals(body.accountPrecondition.nonce, nonce);
+    Party.assertEquals(body.preconditions.account.nonce, nonce);
     body.incrementNonce = Bool(true);
 
     let party = new Party(body);
@@ -795,7 +825,7 @@ function addMissingSignatures(
       if (i === -1) {
         let pk = PublicKey.toBase58(party.body.publicKey);
         throw Error(
-          `addMissingSignatures: Cannot add signature for ${pk}, private key is missing.`
+          `addMissingSignatures: Cannot add signature for fee payer (${pk}), private key is missing.`
         );
       }
       privateKey = additionalKeys[i];
@@ -804,17 +834,17 @@ function addMissingSignatures(
     return { body, authorization: signature };
   }
 
-  function addSignature<P extends Party>(party: P) {
-    party = cloneCircuitValue(party);
+  function addSignature(party: Party) {
+    party = Party.clone(party);
     if (
       !('kind' in party.authorization) ||
       party.authorization.kind !== 'lazy-signature'
     )
-      return party as P & { authorization: Control | LazyProof };
+      return party as Party & { authorization: Control | LazyProof };
     let { privateKey } = party.authorization;
     if (privateKey === undefined) {
-      let i = additionalPublicKeys.findIndex(
-        (pk) => pk === party.body.publicKey
+      let i = additionalPublicKeys.findIndex((pk) =>
+        pk.equals(party.body.publicKey)
       );
       if (i === -1)
         throw Error(
@@ -827,7 +857,7 @@ function addMissingSignatures(
       : commitment;
     let signature = Ledger.signFieldElement(transactionCommitment, privateKey);
     party.authorization = { signature };
-    return party as P & { authorization: Control };
+    return party as Party & { authorization: Control };
   }
   let { feePayer, otherParties } = parties;
   return {
@@ -844,13 +874,13 @@ type PartiesProved = {
 async function addMissingProofs(parties: Parties): Promise<PartiesProved> {
   let partiesJson = JSON.stringify(partiesToJson(parties));
 
-  async function addProof<P extends Party>(party: P, index: number) {
-    party = cloneCircuitValue(party);
+  async function addProof(party: Party, index: number) {
+    party = Party.clone(party);
     if (
       !('kind' in party.authorization) ||
       party.authorization.kind !== 'lazy-proof'
     )
-      return party as P & { authorization: Control | LazySignature };
+      return party as Party & { authorization: Control | LazySignature };
     let { method, args, ZkappClass } = party.authorization;
     let statement = Ledger.transactionStatement(partiesJson, index);
     if (ZkappClass._provers === undefined)
@@ -874,7 +904,7 @@ async function addMissingProofs(parties: Parties): Promise<PartiesProved> {
       () => provers[i](statement)
     );
     party.authorization = { proof: Pickles.proofToString(proof) };
-    return party as P & { authorization: Control | LazySignature };
+    return party as Party & { authorization: Control | LazySignature };
   }
   let { feePayer, otherParties } = parties;
   // compute proofs serially. in parallel would clash with our global variable hacks

--- a/src/lib/precondition.ts
+++ b/src/lib/precondition.ts
@@ -1,0 +1,375 @@
+import {
+  Circuit,
+  AsFieldElements,
+  Bool,
+  Field,
+  jsLayout,
+  Types,
+} from '../snarky';
+import { circuitValueEquals } from './circuit_value';
+import { PublicKey } from './signature';
+import * as Mina from './mina';
+import { Party, Preconditions } from './party';
+import * as GlobalContext from './global-context';
+import { UInt32, UInt64 } from './int';
+
+export {
+  preconditions,
+  Account,
+  Network,
+  assertPreconditionInvariants,
+  AccountValue,
+  NetworkValue,
+};
+
+function preconditions(party: Party, isSelf: boolean) {
+  initializePreconditions(party, isSelf);
+  return { account: Account(party), network: Network(party) };
+}
+
+// note: please keep the two precondition implementations separate
+// so we can add customized fields easily
+
+function Network(party: Party): Network {
+  // TODO there should be a less error-prone way of typing js layout
+  // e.g. separate keys list and value object, so that we can access by key
+  let layout = (jsLayout as any).Party.layout[0].value.layout[9].value.layout[0]
+    .value as Layout;
+  let context = getPreconditionContextExn(party);
+  return preconditionClass(layout, 'network', party, context);
+}
+
+function Account(party: Party): Account {
+  // TODO there should be a less error-prone way of typing js layout
+  // e.g. separate keys list and value object, so that we can access by key
+  let layout = (jsLayout as any).Party.layout[0].value.layout[9].value.layout[1]
+    .value as Layout;
+  let context = getPreconditionContextExn(party);
+  return preconditionClass(layout, 'account', party, context);
+}
+
+function preconditionClass(
+  layout: Layout,
+  baseKey: any,
+  party: Party,
+  context: PreconditionContext
+): any {
+  if (layout.type === 'option') {
+    // range condition
+    if (layout.optionType === 'implicit' && layout.inner.type === 'object') {
+      let lower = layout.inner.layout[0].value.type;
+      let baseType = baseMap[lower];
+      return {
+        ...preconditionSubclass(party, baseKey, baseType as any, context),
+        assertBetween(lower: any, upper: any) {
+          context.constrained.add(baseKey);
+          let property = getPath(party.body.preconditions, baseKey);
+          property.lower = lower;
+          property.upper = upper;
+        },
+      };
+    }
+    // value condition
+    else if (layout.optionType === 'flaggedOption') {
+      let baseType = baseMap[layout.inner.type];
+      return preconditionSubclass(party, baseKey, baseType as any, context);
+    } else if (layout.inner.type !== 'object') {
+      let baseType = baseMap[layout.inner.type];
+      return preconditionSubclass(party, baseKey, baseType as any, context);
+    }
+  } else if (layout.type === 'array') {
+    return {}; // not applicable yet, TODO if we implement state
+  } else if (layout.type === 'object') {
+    // for each field, create a recursive object
+    return Object.fromEntries(
+      layout.layout.map(({ key, value }) => {
+        return [
+          key,
+          preconditionClass(value, `${baseKey}.${key}`, party, context),
+        ];
+      })
+    );
+  } else throw Error('bug');
+}
+
+function preconditionSubclass<
+  K extends LongKey,
+  U extends FlatPreconditionValue[K]
+>(
+  party: Party,
+  longKey: K,
+  fieldType: AsFieldElements<U>,
+  { read, vars, constrained }: PreconditionContext
+) {
+  return {
+    get() {
+      read.add(longKey);
+      return (vars[longKey] ??
+        (vars[longKey] = getVariable(party, longKey, fieldType))) as U;
+    },
+    assertEquals(value: U) {
+      constrained.add(longKey);
+      let property = getPath(
+        party.body.preconditions,
+        longKey
+      ) as AnyCondition<U>;
+      if ('isSome' in property) {
+        property.isSome = Bool(true);
+        property.value = value;
+      } else if ('lower' in property) {
+        property.lower = value;
+        property.upper = value;
+      } else {
+        setPath(party.body.preconditions, longKey, value);
+      }
+    },
+    assertNothing() {
+      constrained.add(longKey);
+    },
+  };
+}
+
+function getVariable<K extends LongKey, U extends FlatPreconditionValue[K]>(
+  party: Party,
+  longKey: K,
+  fieldType: AsFieldElements<U>
+): U {
+  // in compile, just return an empty variable
+  if (GlobalContext.inCompile()) {
+    return Circuit.witness(fieldType, (): U => {
+      throw Error(
+        `This error is thrown because you are reading out the value of a variable, when that value is not known.
+To write a correct circuit, you must avoid any dependency on the concrete value of variables.`
+      );
+    });
+  }
+  // if not in compile, get the variable's value first
+  let [accountOrNetwork, ...rest] = longKey.split('.');
+  let key = rest.join('.');
+  let value: U;
+  if (accountOrNetwork === 'account') {
+    let address = party.body.publicKey;
+    let account: any = Mina.getAccount(address);
+    value = account[key];
+    if (value === undefined)
+      throw Error(
+        `Could not get \`${key}\` on account with public key ${address.toBase58()}. The property may not be available on this account.`
+      );
+  } else if (accountOrNetwork === 'network') {
+    let networkState = Mina.getNetworkState();
+    value = getPath(networkState, key);
+  } else {
+    throw Error('impossible');
+  }
+  // in prover, return a new variable which holds the value
+  // outside, just return the value
+  if (GlobalContext.inProver()) {
+    return Circuit.witness(fieldType, () => value);
+  } else {
+    return value;
+  }
+}
+
+// per-party context for checking invariants on precondition construction
+type PreconditionContext = {
+  isSelf: boolean;
+  vars: Partial<FlatPreconditionValue>;
+  read: Set<LongKey>;
+  constrained: Set<LongKey>;
+};
+
+function initializePreconditions(party: Party, isSelf: boolean) {
+  preconditionContexts.set(party, {
+    read: new Set(),
+    constrained: new Set(),
+    vars: {},
+    isSelf,
+  });
+}
+
+function assertPreconditionInvariants(party: Party) {
+  let context = getPreconditionContextExn(party);
+  let self = context.isSelf ? 'this' : 'party';
+  let dummyPreconditions = Preconditions.ignoreAll();
+  for (let preconditionPath of context.read) {
+    // check if every precondition that was read was also contrained
+    if (context.constrained.has(preconditionPath)) continue;
+
+    // check if the precondition was modified manually, which is also a valid way of avoiding an error
+    let precondition = getPath(party.body.preconditions, preconditionPath);
+    let dummy = getPath(dummyPreconditions, preconditionPath);
+    if (!circuitValueEquals(precondition, dummy)) continue;
+
+    // we accessed a precondition field but not constrained it explicitly - throw an error
+    let hasAssertBetween = isRangeCondition(precondition);
+    let shortPath = preconditionPath.split('.').pop();
+    let errorMessage = `You used \`${self}.${preconditionPath}.get()\` without adding a precondition that links it to the actual ${shortPath}.
+Consider adding this line to your code:
+${self}.${preconditionPath}.assertEquals(${self}.${preconditionPath}.get());${
+      hasAssertBetween
+        ? `
+You can also add more flexible preconditions with \`${self}.${preconditionPath}.assertBetween(...)\`.`
+        : ''
+    }`;
+    throw Error(errorMessage);
+  }
+}
+
+function getPreconditionContextExn(party: Party) {
+  let c = preconditionContexts.get(party);
+  if (c === undefined) throw Error('bug: precondition context not found');
+  return c;
+}
+
+const preconditionContexts = new WeakMap<Party, PreconditionContext>();
+
+// exported types
+
+// TODO actually fetch network preconditions
+type NetworkPrecondition = Preconditions['network'];
+type NetworkValue = PreconditionBaseTypes<NetworkPrecondition>;
+type Network = PreconditionClassType<NetworkPrecondition>;
+
+// TODO: OK how we read delegate from delegateAccount?
+// TODO: no graphql field for provedState yet
+// TODO: figure out serialization of receiptChainHash
+// TODO: OK how we read sequenceState from sequenceEvents?
+// TODO: should we add account.state? then we should change the structure on `Fetch.Account` which is stupid anyway
+// then can just use circuitArray(Field, 8) as the type
+type AccountPrecondition = Omit<Preconditions['account'], 'state'>;
+// TODO to use this type as account type everywhere, need to add publicKey
+type AccountValue = PreconditionBaseTypes<AccountPrecondition>;
+type Account = PreconditionClassType<AccountPrecondition>;
+
+type PreconditionBaseTypes<T> = {
+  [K in keyof T]: T[K] extends RangeCondition<infer U>
+    ? BasicToFull<U>
+    : T[K] extends FlaggedOptionCondition<infer U>
+    ? BasicToFull<U>
+    : T[K] extends AsFieldElements<infer U>
+    ? BasicToFull<U>
+    : PreconditionBaseTypes<T[K]>;
+};
+
+type PreconditionSubclassType<U> = {
+  get(): BasicToFull<U>;
+  assertEquals(value: BasicToFull<U>): void;
+  assertNothing(): void;
+};
+
+type PreconditionClassType<T> = {
+  [K in keyof T]: T[K] extends RangeCondition<infer U>
+    ? PreconditionSubclassType<U> & {
+        assertBetween(lower: BasicToFull<U>, upper: BasicToFull<U>): void;
+      }
+    : T[K] extends FlaggedOptionCondition<infer U>
+    ? PreconditionSubclassType<U>
+    : T[K] extends AsFieldElements<infer U>
+    ? PreconditionSubclassType<U>
+    : PreconditionClassType<T[K]>;
+};
+
+type BasicToFull<K> = K extends Types.UInt32
+  ? UInt32
+  : K extends Types.UInt64
+  ? UInt64
+  : K extends Field
+  ? Field
+  : K extends Bool
+  ? Bool
+  : K extends Types.PublicKey
+  ? PublicKey
+  : never;
+
+// layout types
+
+type BaseLayout = { type: 'UInt64' | 'UInt32' | 'Field' | 'Bool' };
+let baseMap = { UInt64, UInt32, Field, Bool };
+
+type RangeLayout<T extends BaseLayout> = {
+  type: 'object';
+  layout: [{ key: 'lower'; value: T }, { key: 'upper'; value: T }];
+};
+type OptionLayout<T extends BaseLayout> = { type: 'option' } & (
+  | {
+      optionType: 'flaggedOption';
+      inner: T;
+    }
+  | {
+      optionType: 'implicit';
+      inner: RangeLayout<T>;
+    }
+  | {
+      optionType: 'implicit';
+      inner: T;
+    }
+);
+type Layout =
+  | {
+      type: 'object';
+      layout: {
+        key: string;
+        value: Layout;
+      }[];
+    }
+  | {
+      type: 'array';
+      inner: Layout;
+    }
+  | OptionLayout<BaseLayout>
+  | BaseLayout;
+
+// TS magic for computing flattened precondition types
+
+type JoinEntries<K, P> = K extends string
+  ? P extends [string, unknown, unknown]
+    ? [`${K}${P[0] extends '' ? '' : '.'}${P[0]}`, P[1], P[2]]
+    : never
+  : never;
+
+type PreconditionFlatEntry<T> = T extends AnyCondition<infer U>
+  ? ['', T, U]
+  : { [K in keyof T]: JoinEntries<K, PreconditionFlatEntry<T[K]>> }[keyof T];
+
+type FlatPreconditionValue = {
+  [S in PreconditionFlatEntry<NetworkPrecondition> as `network.${S[0]}`]: S[2];
+} & {
+  [S in PreconditionFlatEntry<AccountPrecondition> as `account.${S[0]}`]: S[2];
+};
+type FlatPrecondition = {
+  [S in PreconditionFlatEntry<NetworkPrecondition> as `network.${S[0]}`]: S[1];
+} & {
+  [S in PreconditionFlatEntry<AccountPrecondition> as `account.${S[0]}`]: S[1];
+};
+
+type LongKey = keyof FlatPreconditionValue;
+
+// types for the two kinds of conditions
+type RangeCondition<T> = { lower: T; upper: T };
+type FlaggedOptionCondition<T> = { isSome: Bool; value: T };
+type AnyCondition<T> =
+  | RangeCondition<T>
+  | FlaggedOptionCondition<T>
+  | AsFieldElements<T>;
+
+function isRangeCondition<T>(
+  condition: AnyCondition<T>
+): condition is RangeCondition<T> {
+  return 'lower' in condition;
+}
+
+// helper. getPath({a: {b: 'x'}}, 'a.b') === 'x'
+// TODO: would be awesome to type this
+function getPath(obj: any, path: string) {
+  let pathArray = path.split('.').reverse();
+  while (pathArray.length > 0) {
+    let key = pathArray.pop();
+    obj = obj[key as any];
+  }
+  return obj;
+}
+function setPath(obj: any, path: string, value: any) {
+  let pathArray = path.split('.');
+  let key = pathArray.pop()!;
+  getPath(obj, pathArray.join('.'))[key] = value;
+}

--- a/src/lib/primitives.test.ts
+++ b/src/lib/primitives.test.ts
@@ -1,0 +1,409 @@
+import { isReady, shutdown, Field, Bool, Circuit } from '../../dist/server';
+
+describe('bool', () => {
+  beforeAll(async () => {
+    await isReady;
+    return;
+  });
+
+  afterAll(async () => {
+    setTimeout(async () => {
+      await shutdown();
+    }, 0);
+  });
+
+  describe('inside circuit', () => {
+    describe('toField', () => {
+      it('should return a Field', async () => {
+        expect(true).toEqual(true);
+      });
+      it('should convert false to Field element 0', () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+
+            xFalse.toField().assertEquals(new Field(0));
+          });
+        }).not.toThrow();
+      });
+      it('should throw when false toString is compared to Field element other than 0 ', () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            xFalse.toField().assertEquals(new Field(1));
+          });
+        }).toThrow();
+      });
+
+      it('should convert true to Field element 1', () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            xTrue.toField().assertEquals(new Field(1));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw when true toField is compared to Field element other than 1 ', () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            xTrue.toField().assertEquals(new Field(0));
+          });
+        }).toThrow();
+      });
+    });
+
+    describe('toFields', () => {
+      it('should return an array of Fields', () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const x = Circuit.witness(Bool, () => new Bool(false));
+            const fieldArr = x.toFields();
+            const isArr = Array.isArray(fieldArr);
+            expect(isArr).toBe(true);
+            fieldArr[0].assertEquals(new Field(0));
+          });
+        }).not.toThrow();
+      });
+    });
+    describe('and', () => {
+      it('true "and" true should return true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xTrue.and(yTrue).assertEquals(new Bool(true));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if true "and" true is compared to false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xTrue.and(yTrue).assertEquals(new Bool(false));
+          });
+        }).toThrow();
+      });
+
+      it('false "and" false should return false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yFalse = Circuit.witness(Bool, () => new Bool(false));
+
+            xFalse.and(yFalse).assertEquals(new Bool(false));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if false "and" false is compared to true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yFalse = Circuit.witness(Bool, () => new Bool(false));
+
+            xFalse.and(yFalse).assertEquals(new Bool(true));
+          });
+        }).toThrow();
+      });
+
+      it('false "and" true should return false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xFalse.and(yTrue).assertEquals(new Bool(false));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if false "and" true is compared to true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xFalse.and(yTrue).assertEquals(new Bool(true));
+          });
+        }).toThrow();
+      });
+    });
+
+    describe('not', () => {
+      it('should return true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            xTrue.toField().assertEquals(new Field(1));
+          });
+        }).not.toThrow();
+      });
+      it('should return a new bool that is the negation of the input', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            const yFalse = Circuit.witness(Bool, () => new Bool(false));
+            xTrue.not().assertEquals(new Bool(false));
+            yFalse.not().assertEquals(new Bool(true));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if input.not() is compared to input', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            xTrue.not().assertEquals(xTrue);
+          });
+        }).toThrow();
+      });
+    });
+
+    describe('or', () => {
+      it('true "or" true should return true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xTrue.or(yTrue).assertEquals(new Bool(true));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if true "or" true is compared to false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xTrue.or(yTrue).assertEquals(new Bool(false));
+          });
+        }).toThrow();
+      });
+
+      it('false "or" false should return false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yFalse = Circuit.witness(Bool, () => new Bool(false));
+
+            xFalse.or(yFalse).assertEquals(new Bool(false));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if false "or" false is compared to true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yFalse = Circuit.witness(Bool, () => new Bool(false));
+
+            xFalse.or(yFalse).assertEquals(new Bool(true));
+          });
+        }).toThrow();
+      });
+
+      it('false "or" true should return true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xFalse.or(yTrue).assertEquals(new Bool(true));
+          });
+        }).not.toThrow();
+      });
+    });
+
+    describe('assertEquals', () => {
+      it('should not throw on true "assertEqual" true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const x = Circuit.witness(Bool, () => new Bool(true));
+
+            x.assertEquals(x);
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw on true "assertEquals" false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const x = Circuit.witness(Bool, () => new Bool(true));
+            const y = Circuit.witness(Bool, () => new Bool(false));
+
+            x.assertEquals(y);
+          });
+        }).toThrow();
+      });
+    });
+    describe('equals', () => {
+      it('should not throw on true "equals" true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const x = Circuit.witness(Bool, () => new Bool(true));
+
+            x.equals(x).assertEquals(true);
+          });
+        }).not.toThrow();
+      });
+      it('should throw on true "equals" false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const x = Circuit.witness(Bool, () => new Bool(true));
+            const y = Circuit.witness(Bool, () => new Bool(false));
+            x.equals(y).assertEquals(true);
+          });
+        }).toThrow();
+      });
+    });
+  });
+  describe('outside circuit', () => {
+    describe('toField', () => {
+      it('should convert false to Field element 0', () => {
+        expect(new Bool(false).toField()).toEqual(new Field(0));
+      });
+      it('should throw when false toField is compared to Field element other than 0 ', () => {
+        expect(() => {
+          expect(new Bool(false).toField()).toEqual(new Field(1));
+        }).toThrow();
+      });
+
+      it('should convert true to Field element 1', () => {
+        expect(new Bool(true).toField()).toEqual(new Field(1));
+      });
+
+      it('should throw when true toField is compared to Field element other than 1 ', () => {
+        expect(() => {
+          expect(new Bool(true).toField()).toEqual(new Field(0));
+        }).toThrow();
+      });
+    });
+
+    describe('toFields', () => {
+      it('should return an array of Fields', () => {
+        const x = new Bool(false);
+        const fieldArr = x.toFields();
+        const isArr = Array.isArray(fieldArr);
+        expect(isArr).toBe(true);
+        expect(fieldArr[0]).toEqual(new Field(0));
+      });
+    });
+    describe('and', () => {
+      it('true "and" true should return true', async () => {
+        const xTrue = new Bool(true);
+        const yTrue = new Bool(true);
+        expect(xTrue.and(yTrue)).toEqual(new Bool(true));
+      });
+
+      it('should throw if true "and" true is compared to false', async () => {
+        expect(() => {
+          const xTrue = new Bool(true);
+          const yTrue = new Bool(true);
+          expect(xTrue.and(yTrue)).toEqual(new Bool(false));
+        }).toThrow();
+      });
+
+      it('false "and" false should return false', async () => {
+        const xFalse = new Bool(false);
+        const yFalse = new Bool(false);
+        expect(xFalse.and(yFalse)).toEqual(new Bool(false));
+      });
+
+      it('should throw if false "and" false is compared to true', async () => {
+        expect(() => {
+          const xFalse = new Bool(false);
+          const yFalse = new Bool(false);
+          expect(xFalse.and(yFalse)).toEqual(new Bool(true));
+        }).toThrow();
+      });
+
+      it('false "and" true should return false', async () => {
+        const xFalse = new Bool(false);
+        const yTrue = new Bool(true);
+        expect(xFalse.and(yTrue)).toEqual(new Bool(false));
+      });
+
+      it('should throw if false "and" true is compared to true', async () => {
+        expect(() => {
+          const xFalse = new Bool(false);
+          const yFalse = new Bool(false);
+          expect(xFalse.and(yFalse)).toEqual(new Bool(true));
+        }).toThrow();
+      });
+    });
+    describe('not', () => {
+      it('should return a new bool that is the negation of the input', async () => {
+        const xTrue = new Bool(true);
+        const yFalse = new Bool(false);
+        expect(xTrue.not()).toEqual(new Bool(false));
+        expect(yFalse.not()).toEqual(new Bool(true));
+      });
+
+      it('should throw if input.not() is compared to input', async () => {
+        expect(() => {
+          const xTrue = new Bool(true);
+
+          xTrue.not().assertEquals(xTrue);
+        }).toThrow();
+      });
+    });
+
+    describe('or', () => {
+      it('true "or" true should return true', async () => {
+        const xTrue = new Bool(true);
+        const yTrue = new Bool(true);
+
+        xTrue.or(yTrue).assertEquals(new Bool(true));
+      });
+
+      it('should throw if true "or" true is compared to false', async () => {
+        expect(() => {
+          const xTrue = new Bool(true);
+          const yTrue = new Bool(true);
+
+          expect(xTrue.or(yTrue)).toEqual(new Bool(false));
+        }).toThrow();
+      });
+
+      it('false "or" false should return false', async () => {
+        const xFalse = new Bool(false);
+        const yFalse = new Bool(false);
+
+        expect(xFalse.or(yFalse)).toEqual(new Bool(false));
+      });
+
+      it('should throw if false "or" false is compared to true', async () => {
+        expect(() => {
+          const xFalse = new Bool(false);
+          const yFalse = new Bool(false);
+
+          expect(xFalse.or(yFalse)).toEqual(new Bool(true));
+        }).toThrow();
+      });
+
+      it('false "or" true should return true', async () => {
+        const xFalse = new Bool(false);
+        const yTrue = new Bool(true);
+        xFalse.or(yTrue).assertEquals(new Bool(true));
+      });
+    });
+    describe('toBoolean', () => {
+      it('should return a true javascript boolean', () => {
+        const xTrue = new Bool(true);
+        expect(xTrue.toBoolean()).toEqual(true);
+      });
+      it('should return a false javascript boolean', () => {
+        const xFalse = new Bool(false);
+        expect(xFalse.toBoolean()).toEqual(false);
+      });
+    });
+  });
+});

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,0 +1,277 @@
+import { Circuit, Field, Bool, AsFieldElements } from '../snarky';
+import { Party } from './party';
+import { PublicKey } from './signature';
+import * as Mina from './mina';
+import { Account, fetchAccount } from './fetch';
+import * as GlobalContext from './global-context';
+import { SmartContract } from './zkapp';
+
+export { State, state, declareState };
+
+/**
+ * Gettable and settable state that can be checked for equality.
+ */
+type State<A> = {
+  get(): A;
+  set(a: A): void;
+  fetch(): Promise<A | undefined>;
+  assertEquals(a: A): void;
+};
+function State<A>(): State<A> {
+  return createState<A>();
+}
+
+/**
+ * A decorator to use within a zkapp to indicate what will be stored on-chain.
+ * For example, if you want to store a field element `some_state` in a zkapp,
+ * you can use the following in the declaration of your zkapp:
+ *
+ * ```
+ * @state(Field) some_state = State<Field>();
+ * ```
+ *
+ */
+function state<A>(stateType: AsFieldElements<A>) {
+  return function (
+    target: SmartContract & { constructor: any },
+    key: string,
+    _descriptor?: PropertyDescriptor
+  ) {
+    const ZkappClass = target.constructor;
+    if (reservedPropNames.has(key)) {
+      throw Error(`Property name ${key} is reserved.`);
+    }
+    let sc = smartContracts.get(ZkappClass);
+    if (sc === undefined) {
+      sc = { states: [], layout: undefined };
+      smartContracts.set(ZkappClass, sc);
+    }
+    sc.states.push([key, stateType]);
+
+    Object.defineProperty(target, key, {
+      get(this) {
+        return this._?.[key];
+      },
+      set(this, v: InternalStateType<A>) {
+        if (v._contract !== undefined)
+          throw Error(
+            'A State should only be assigned once to a SmartContract'
+          );
+        if (this._?.[key]) throw Error('A @state should only be assigned once');
+        v._contract = {
+          key,
+          stateType: stateType,
+          instance: this,
+          class: ZkappClass,
+        };
+        (this._ ?? (this._ = {}))[key] = v;
+      },
+    });
+  };
+}
+
+/**
+ * `declareState` can be used in place of the `@state` decorator to declare on-chain state on a SmartContract.
+ * It should be placed _after_ the class declaration.
+ * Here is an example of declaring a state property `x` of type `Field`.
+ * ```ts
+ * class MyContract extends SmartContract {
+ *   x = State<Field>();
+ *   // ...
+ * }
+ * declareState(MyContract, { x: Field });
+ * ```
+ *
+ * If you're using pure JS, it's _not_ possible to use the built-in class field syntax,
+ * i.e. the following will _not_ work:
+ *
+ * ```js
+ * // THIS IS WRONG IN JS!
+ * class MyContract extends SmartContract {
+ *   x = State();
+ * }
+ * declareState(MyContract, { x: Field });
+ * ```
+ *
+ * Instead, add a constructor where you assign the property:
+ * ```js
+ * class MyContract extends SmartContract {
+ *   constructor(x) {
+ *     super();
+ *     this.x = State();
+ *   }
+ * }
+ * declareState(MyContract, { x: Field });
+ * ```
+ */
+function declareState<T extends typeof SmartContract>(
+  SmartContract: T,
+  states: Record<string, AsFieldElements<unknown>>
+) {
+  for (let key in states) {
+    let CircuitValue = states[key];
+    state(CircuitValue)(SmartContract.prototype, key);
+  }
+}
+
+// metadata defined by @state, which link state to a particular SmartContract
+type StateAttachedContract<A> = {
+  key: string;
+  stateType: AsFieldElements<A>;
+  instance: SmartContract;
+  class: typeof SmartContract;
+};
+
+type InternalStateType<A> = State<A> & { _contract?: StateAttachedContract<A> };
+
+function createState<T>(): InternalStateType<T> {
+  return {
+    _contract: undefined as StateAttachedContract<T> | undefined,
+
+    set(state: T) {
+      if (this._contract === undefined)
+        throw Error(
+          'set can only be called when the State is assigned to a SmartContract @state.'
+        );
+      let layout = getLayoutPosition(this._contract);
+      let stateAsFields = this._contract.stateType.toFields(state);
+      let party = this._contract.instance.self;
+      stateAsFields.forEach((x, i) => {
+        Party.setValue(party.body.update.appState[layout.offset + i], x);
+      });
+    },
+
+    assertEquals(state: T) {
+      if (this._contract === undefined)
+        throw Error(
+          'assertEquals can only be called when the State is assigned to a SmartContract @state.'
+        );
+      let layout = getLayoutPosition(this._contract);
+      let stateAsFields = this._contract.stateType.toFields(state);
+      let party = this._contract.instance.self;
+      stateAsFields.forEach((x, i) => {
+        Party.assertEquals(
+          party.body.preconditions.account.state[layout.offset + i],
+          x
+        );
+      });
+    },
+
+    get() {
+      if (this._contract === undefined)
+        throw Error(
+          'get can only be called when the State is assigned to a SmartContract @state.'
+        );
+      let layout = getLayoutPosition(this._contract);
+      let address: PublicKey = this._contract.instance.address;
+      let stateAsFields: Field[];
+      let inProver = GlobalContext.inProver();
+      if (!GlobalContext.inCompile()) {
+        let account: Account;
+        try {
+          account = Mina.getAccount(address);
+        } catch (err) {
+          // TODO: there should also be a reasonable error here
+          if (inProver) {
+            throw err;
+          }
+          throw Error(
+            `${this._contract.key}.get() failed, because the zkapp account was not found in the cache. ` +
+              `Try calling \`await fetchAccount(zkappAddress)\` first.`
+          );
+        }
+        if (account.zkapp === undefined) {
+          // if the account is not a zkapp account, let the default state be all zeroes
+          stateAsFields = Array(layout.length).fill(Field.zero);
+        } else {
+          stateAsFields = [];
+          for (let i = 0; i < layout.length; ++i) {
+            stateAsFields.push(account.zkapp.appState[layout.offset + i]);
+          }
+        }
+        // in prover, create a new witness with the state values
+        // outside, just return the state values
+        stateAsFields = inProver
+          ? Circuit.witness(
+              Circuit.array(Field, layout.length),
+              () => stateAsFields
+            )
+          : stateAsFields;
+      } else {
+        // in compile, we don't need the witness values
+        stateAsFields = Circuit.witness(
+          Circuit.array(Field, layout.length),
+          (): Field[] => {
+            throw Error('this should never happen');
+          }
+        );
+      }
+      let state = this._contract.stateType.ofFields(stateAsFields);
+      this._contract.stateType.check?.(state);
+      return state;
+    },
+
+    async fetch() {
+      if (this._contract === undefined)
+        throw Error(
+          'fetch can only be called when the State is assigned to a SmartContract @state.'
+        );
+      if (Mina.currentTransaction !== undefined)
+        throw Error(
+          'fetch is not intended to be called inside a transaction block.'
+        );
+      let layout = getLayoutPosition(this._contract);
+      let address: PublicKey = this._contract.instance.address;
+      let { account } = await fetchAccount(address);
+      if (account === undefined) return undefined;
+      let stateAsFields: Field[];
+      if (account.zkapp === undefined) {
+        stateAsFields = Array(layout.length).fill(Field.zero);
+      } else {
+        stateAsFields = [];
+        for (let i = 0; i < layout.length; i++) {
+          stateAsFields.push(account.zkapp.appState[layout.offset + i]);
+        }
+      }
+      return this._contract.stateType.ofFields(stateAsFields);
+    },
+  };
+}
+
+function getLayoutPosition<A>({
+  key,
+  class: contractClass,
+}: StateAttachedContract<A>) {
+  let layout = getLayout(contractClass);
+  let stateLayout = layout.get(key);
+  if (stateLayout === undefined) {
+    throw new Error(`state ${key} not found`);
+  }
+  return stateLayout;
+}
+
+function getLayout(scClass: typeof SmartContract) {
+  let sc = smartContracts.get(scClass);
+  if (sc === undefined) throw Error('bug');
+  if (sc.layout === undefined) {
+    let layout = new Map();
+    sc.layout = layout;
+    let offset = 0;
+    sc.states.forEach(([key, stateType]) => {
+      let length = stateType.sizeInFields();
+      layout.set(key, { offset, length });
+      offset += length;
+    });
+  }
+  return sc.layout;
+}
+
+const smartContracts = new WeakMap<
+  typeof SmartContract,
+  {
+    states: [string, AsFieldElements<any>][];
+    layout: Map<string, { offset: number; length: number }> | undefined;
+  }
+>();
+
+const reservedPropNames = new Set(['_methods', '_']);

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -1,7 +1,6 @@
 import {
   Circuit,
   Field,
-  Bool,
   Poseidon,
   AsFieldElements,
   Ledger,
@@ -20,243 +19,19 @@ import {
 import { PrivateKey, PublicKey } from './signature';
 import * as Mina from './mina';
 import { UInt32, UInt64 } from './int';
-import { Account, fetchAccount } from './fetch';
 import {
   withContext,
   withContextAsync,
   getContext,
-  mainContext,
+  getExecutionState,
+  selfParty,
+  inCompile,
 } from './global-context';
-import * as GlobalContext from './global-context';
+import { assertPreconditionInvariants } from './precondition';
 
-export {
-  deploy,
-  DeployArgs,
-  call,
-  callUnproved,
-  signFeePayer,
-  declareState,
-  declareMethods,
-};
+export { deploy, DeployArgs, call, callUnproved, signFeePayer, declareMethods };
 
-/**
- * Gettable and settable state that can be checked for equality.
- */
-export type State<A> = {
-  get(): A;
-  set(a: A): void;
-  fetch(): Promise<A | undefined>;
-  assertEquals(a: A): void;
-};
-
-/**
- * Gettable and settable state that can be checked for equality.
- */
-export function State<A>(): State<A> {
-  return createState<A>();
-}
-
-function createState<A>() {
-  return {
-    _initialized: false,
-    _key: undefined as never as string, // defined by @state
-    _ty: undefined as never as AsFieldElements<A>, // defined by @state
-    _this: undefined as never as SmartContract, // defined by @state
-    _ZkappClass: undefined as never as typeof SmartContract & {
-      _layout: () => any;
-    }, // defined by @state
-
-    _init(key: string, ty: AsFieldElements<A>, _this: any, ZkappClass: any) {
-      this._initialized = true;
-      this._key = key;
-      this._ty = ty;
-      this._this = _this;
-      this._ZkappClass = ZkappClass;
-    },
-
-    getLayout() {
-      let layout: Map<string, { offset: number; length: number }> =
-        this._ZkappClass._layout();
-      let stateLayout = layout.get(this._key);
-      if (stateLayout === undefined) {
-        throw new Error(`state ${this._key} not found`);
-      }
-      return stateLayout;
-    },
-
-    set(a: A) {
-      if (!this._initialized)
-        throw Error(
-          'set can only be called when the State is assigned to a SmartContract @state.'
-        );
-      let layout = this.getLayout();
-      let stateAsFields = this._ty.toFields(a);
-      let e: ExecutionState = this._this.executionState();
-
-      stateAsFields.forEach((x, i) => {
-        Party.setValue(e.party.body.update.appState[layout.offset + i], x);
-      });
-    },
-
-    assertEquals(a: A) {
-      if (!this._initialized)
-        throw Error(
-          'assertEquals can only be called when the State is assigned to a SmartContract @state.'
-        );
-      let layout = this.getLayout();
-      let stateAsFields = this._ty.toFields(a);
-      let e: ExecutionState = this._this.executionState();
-
-      stateAsFields.forEach((x, i) => {
-        e.party.body.accountPrecondition.state[layout.offset + i].isSome =
-          Bool(true);
-        e.party.body.accountPrecondition.state[layout.offset + i].value = x;
-      });
-    },
-
-    get() {
-      if (!this._initialized)
-        throw Error(
-          'get can only be called when the State is assigned to a SmartContract @state.'
-        );
-      let layout = this.getLayout();
-
-      let address: PublicKey = this._this.address;
-      let stateAsFields: Field[];
-      let inProver = GlobalContext.inProver();
-      if (!GlobalContext.inCompile()) {
-        let a: Account;
-        try {
-          a = Mina.getAccount(address);
-        } catch (err) {
-          // TODO: there should also be a reasonable error here
-          if (inProver) {
-            throw err;
-          }
-          throw Error(
-            `${this._key}.get() failed, because the zkapp account was not found in the cache. ` +
-              `Try calling \`await fetchAccount(zkappAddress)\` first.`
-          );
-        }
-        if (a.zkapp === undefined) {
-          // if the account is not a zkapp account, let the default state be all zeroes
-          stateAsFields = Array(layout.length).fill(Field.zero);
-        } else {
-          stateAsFields = [];
-          for (let i = 0; i < layout.length; ++i) {
-            stateAsFields.push(a.zkapp.appState[layout.offset + i]);
-          }
-        }
-        // in prover, create a new witness with the state values
-        // outside, just return the state values
-        stateAsFields = inProver
-          ? Circuit.witness(
-              Circuit.array(Field, layout.length),
-              () => stateAsFields
-            )
-          : stateAsFields;
-      } else {
-        // in compile, we don't need the witness values
-        stateAsFields = Circuit.witness(
-          Circuit.array(Field, layout.length),
-          (): Field[] => {
-            throw Error('this should never happen');
-          }
-        );
-      }
-      let state = this._ty.ofFields(stateAsFields);
-      (this._ty as any).check?.(state);
-      return state;
-    },
-
-    async fetch() {
-      if (!this._initialized)
-        throw Error(
-          'fetch can only be called when the State is assigned to a SmartContract @state.'
-        );
-      if (Mina.currentTransaction !== undefined)
-        throw Error(
-          'fetch is not intended to be called inside a transaction block.'
-        );
-      let layout = this.getLayout();
-      let address: PublicKey = this._this.address;
-      let { account } = await fetchAccount(address);
-      if (account === undefined) return undefined;
-      let stateAsFields: Field[];
-      if (account.zkapp === undefined) {
-        stateAsFields = Array(layout.length).fill(Field.zero);
-      } else {
-        stateAsFields = [];
-        for (let i = 0; i < layout.length; ++i) {
-          stateAsFields.push(account.zkapp.appState[layout.offset + i]);
-        }
-      }
-      return this._ty.ofFields(stateAsFields);
-    },
-  };
-}
-
-type InternalStateType = ReturnType<typeof createState>;
-
-const reservedPropNames = new Set(['_states', '_layout', '_methods', '_']);
-
-/**
- * A decorator to use within a zkapp to indicate what will be stored on-chain.
- * For example, if you want to store a field element `some_state` in a zkapp,
- * you can use the following in the declaration of your zkapp:
- *
- * ```
- * @state(Field) some_state = State<Field>();
- * ```
- *
- */
-export function state<A>(ty: AsFieldElements<A>) {
-  return function (
-    target: SmartContract & { constructor: any },
-    key: string,
-    _descriptor?: PropertyDescriptor
-  ) {
-    const ZkappClass = target.constructor;
-    if (reservedPropNames.has(key)) {
-      throw Error(`Property name ${key} is reserved.`);
-    }
-
-    if (ZkappClass._states == undefined) {
-      ZkappClass._states = [];
-      let layout: Map<string, { offset: number; length: number }>;
-      ZkappClass._layout = () => {
-        if (layout === undefined) {
-          layout = new Map();
-
-          let offset = 0;
-          ZkappClass._states.forEach(([key, ty]: [any, any]) => {
-            let length = ty.sizeInFields();
-            layout.set(key, { offset, length });
-            offset += length;
-          });
-        }
-        return layout;
-      };
-    }
-
-    ZkappClass._states.push([key, ty]);
-
-    Object.defineProperty(target, key, {
-      get(this) {
-        return this._?.[key];
-      },
-      set(this, v: InternalStateType) {
-        if (v._initialized)
-          throw Error(
-            'A State should only be assigned once to a SmartContract'
-          );
-        if (this._?.[key]) throw Error('A @state should only be assigned once');
-        v._init(key, ty, this, ZkappClass);
-        (this._ ?? (this._ = {}))[key] = v;
-      },
-    });
-  };
-}
+const reservedPropNames = new Set(['_methods', '_']);
 
 /**
  * A decorator to use in a zkapp to mark a method as callable by anyone.
@@ -322,6 +97,13 @@ function wrapMethod(
     let actualArgs = args.slice(0, argsLength);
     let shouldCallDirectly = args[argsLength] as undefined | boolean;
     if (Mina.currentTransaction === undefined || shouldCallDirectly === true) {
+      // in compile, check the self party right after calling the method
+      // TODO: this needs to be done in a unified way for all parties that are created
+      if (inCompile()) {
+        let result = method.apply(this, actualArgs);
+        assertPreconditionInvariants(this.self);
+        return result;
+      }
       // outside a transaction, just call the method
       return method.apply(this, actualArgs);
     } else {
@@ -426,7 +208,6 @@ function picklesRuleFromFunction(
 export class SmartContract {
   address: PublicKey;
 
-  _executionState?: ExecutionState;
   static _methods?: methodEntry<SmartContract>[];
   static _provers?: Prover[];
   static _verificationKey?: { data: string; hash: Field };
@@ -451,7 +232,7 @@ export class SmartContract {
     );
 
     let [, { getVerificationKeyArtifact, provers, verify }] = withContext(
-      { self: Party.defaultParty(address), inCompile: true },
+      { self: selfParty(address), inCompile: true },
       () => Pickles.compile(rules)
     );
     let verificationKey = getVerificationKeyArtifact();
@@ -555,44 +336,16 @@ export class SmartContract {
     return { statement, selfParty };
   }
 
-  executionState(): ExecutionState {
-    // TODO reconcile mainContext with currentTransaction
-    if (mainContext !== undefined) {
-      return {
-        transactionId: 0,
-        partyIndex: 0,
-        party: mainContext.self,
-      };
-    }
-
-    if (Mina.currentTransaction === undefined) {
-      throw new Error('Cannot execute outside of a Mina.transaction() block.');
-    }
-
-    if (
-      this._executionState !== undefined &&
-      this._executionState.transactionId === Mina.nextTransactionId.value
-    ) {
-      return this._executionState;
-    } else {
-      const id = Mina.nextTransactionId.value;
-      const index = Mina.currentTransaction.nextPartyIndex++;
-      const body = Body.keepAll(this.address);
-      const party = new Party(body);
-      Mina.currentTransaction.parties.push(party);
-
-      const s = {
-        transactionId: id,
-        partyIndex: index,
-        party,
-      };
-      this._executionState = s;
-      return s;
-    }
+  get self() {
+    return getExecutionState(this).party;
   }
 
-  get self() {
-    return this.executionState().party;
+  get account() {
+    return this.self.account;
+  }
+
+  get network() {
+    return this.self.network;
   }
 
   get balance() {
@@ -631,12 +384,6 @@ export class SmartContract {
 type DeployArgs = {
   verificationKey?: { data: string; hash: string | Field };
   zkappKey?: PrivateKey;
-};
-
-type ExecutionState = {
-  transactionId: number;
-  partyIndex: number;
-  party: Party;
 };
 
 function emptyWitness<A>(typ: AsFieldElements<A>) {
@@ -814,50 +561,6 @@ function signFeePayer(
 }
 
 // alternative API which can replace decorators, works in pure JS
-
-/**
- * `declareState` can be used in place of the `@state` decorator to declare on-chain state on a SmartContract.
- * It should be placed _after_ the class declaration.
- * Here is an example of declaring a state property `x` of type `Field`.
- * ```ts
- * class MyContract extends SmartContract {
- *   x = State<Field>();
- *   // ...
- * }
- * declareState(MyContract, { x: Field });
- * ```
- *
- * If you're using pure JS, it's _not_ possible to use the built-in class field syntax,
- * i.e. the following will _not_ work:
- *
- * ```js
- * // THIS IS WRONG IN JS!
- * class MyContract extends SmartContract {
- *   x = State();
- * }
- * declareState(MyContract, { x: Field });
- * ```
- *
- * Instead, add a constructor where you assign the property:
- * ```js
- * class MyContract extends SmartContract {
- *   constructor(x) {
- *     super();
- *     this.x = State();
- *   }
- * }
- * declareState(MyContract, { x: Field });
- * ```
- */
-function declareState<T extends typeof SmartContract>(
-  SmartContract: T,
-  states: Record<string, AsFieldElements<unknown>>
-) {
-  for (let key in states) {
-    let CircuitValue = states[key];
-    state(CircuitValue)(SmartContract.prototype, key);
-  }
-}
 
 /**
  * `declareMethods` can be used in place of the `@method` decorator

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -18,6 +18,7 @@ export {
   JSONValue,
 };
 export * as Types from './snarky/gen/parties';
+export { jsLayout } from './snarky/gen/js-layout';
 
 /**
  * An element of a finite field.
@@ -385,10 +386,20 @@ declare class Bool {
   or(y: Bool | boolean): Bool;
 
   /**
-   * Aborts the program if this [[`Bool`]] is equal to `y`.
+   * Proves that this [[`Bool`]] is equal to `y`.
    * @param y a [[`Bool`]].
    */
   assertEquals(y: Bool | boolean): void;
+
+  /**
+   * Proves that this [[`Bool`]] is `true`.
+   */
+  assertTrue(): void;
+
+  /**
+   * Proves that this [[`Bool`]] is `false`.
+   */
+  assertFalse(): void;
 
   /**
    * Returns true if this [[`Bool`]] is equal to `y`.
@@ -417,6 +428,15 @@ declare class Bool {
   toBoolean(): boolean;
 
   /* static members */
+  /**
+   * The constant [[`Bool`]] that is `true`.
+   */
+  static true: Bool;
+  /**
+   * The constant [[`Bool`]] that is `false`.
+   */
+  static false: Bool;
+
   static toField(x: Bool | boolean): Field;
 
   static Unsafe: {
@@ -451,6 +471,7 @@ declare interface AsFieldElements<T> {
   toFields(x: T): Field[];
   ofFields(x: Field[]): T;
   sizeInFields(): number;
+  check?: (x: T) => void;
 }
 
 declare interface CircuitMain<W, P> {
@@ -590,7 +611,7 @@ declare class Group {
   sub(y: Group): Group;
   neg(): Group;
   scale(y: Scalar): Group;
-  endoScale(y: EndoScalar): Group;
+  // TODO: Add this function when OCaml bindings are implemented : endoScale(y: EndoScalar): Group;
 
   assertEquals(y: Group): void;
   equals(y: Group): Bool;
@@ -611,7 +632,7 @@ declare class Group {
   static sub(x: Group, y: Group): Group;
   static neg(x: Group): Group;
   static scale(x: Group, y: Scalar): Group;
-  static endoScale(x: Group, y: EndoScalar): Group;
+  // TODO: Add this function when OCaml bindings are implemented : static endoScale(x: Group, y: EndoScalar): Group;
 
   static assertEqual(x: Group, y: Group): void;
   static equal(x: Group, y: Group): Bool;
@@ -621,7 +642,13 @@ declare class Group {
   static sizeInFields(): number;
 
   static toJSON(x: Group): JSONValue;
-  static fromJSON(x: JSONValue): Group | null;
+  static fromJSON({
+    x,
+    y,
+  }: {
+    x: string | number;
+    y: string | number;
+  }): Group | null;
 }
 
 declare class Sponge {

--- a/src/snarky/gen/js-layout.ts
+++ b/src/snarky/gen/js-layout.ts
@@ -318,10 +318,10 @@ let jsLayout = {
                     docs: null,
                   },
                   {
-                    key: 'protocolStatePrecondition',
+                    key: 'networkPrecondition',
                     value: {
                       type: 'object',
-                      name: 'ProtocolStatePrecondition',
+                      name: 'NetworkPrecondition',
                       docs: null,
                       layout: [
                         {
@@ -1058,252 +1058,55 @@ let jsLayout = {
                     { key: 'callData', value: { type: 'Field' }, docs: null },
                     { key: 'callDepth', value: { type: 'number' }, docs: null },
                     {
-                      key: 'protocolStatePrecondition',
+                      key: 'preconditions',
                       value: {
                         type: 'object',
-                        name: 'ProtocolStatePrecondition',
+                        name: 'Preconditions',
                         docs: null,
                         layout: [
                           {
-                            key: 'snarkedLedgerHash',
-                            value: {
-                              type: 'option',
-                              optionType: 'flaggedOption',
-                              inner: { type: 'Field' },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'timestamp',
-                            value: {
-                              type: 'option',
-                              optionType: 'implicit',
-                              inner: {
-                                type: 'object',
-                                name: 'BlockTimeInterval',
-                                docs: null,
-                                layout: [
-                                  {
-                                    key: 'lower',
-                                    value: { type: 'UInt64' },
-                                    docs: null,
-                                  },
-                                  {
-                                    key: 'upper',
-                                    value: { type: 'UInt64' },
-                                    docs: null,
-                                  },
-                                ],
-                              },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'blockchainLength',
-                            value: {
-                              type: 'option',
-                              optionType: 'implicit',
-                              inner: {
-                                type: 'object',
-                                name: 'LengthInterval',
-                                docs: null,
-                                layout: [
-                                  {
-                                    key: 'lower',
-                                    value: { type: 'UInt32' },
-                                    docs: null,
-                                  },
-                                  {
-                                    key: 'upper',
-                                    value: { type: 'UInt32' },
-                                    docs: null,
-                                  },
-                                ],
-                              },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'minWindowDensity',
-                            value: {
-                              type: 'option',
-                              optionType: 'implicit',
-                              inner: {
-                                type: 'object',
-                                name: 'LengthInterval',
-                                docs: null,
-                                layout: [
-                                  {
-                                    key: 'lower',
-                                    value: { type: 'UInt32' },
-                                    docs: null,
-                                  },
-                                  {
-                                    key: 'upper',
-                                    value: { type: 'UInt32' },
-                                    docs: null,
-                                  },
-                                ],
-                              },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'totalCurrency',
-                            value: {
-                              type: 'option',
-                              optionType: 'implicit',
-                              inner: {
-                                type: 'object',
-                                name: 'CurrencyAmountInterval',
-                                docs: null,
-                                layout: [
-                                  {
-                                    key: 'lower',
-                                    value: { type: 'UInt64' },
-                                    docs: null,
-                                  },
-                                  {
-                                    key: 'upper',
-                                    value: { type: 'UInt64' },
-                                    docs: null,
-                                  },
-                                ],
-                              },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'globalSlotSinceHardFork',
-                            value: {
-                              type: 'option',
-                              optionType: 'implicit',
-                              inner: {
-                                type: 'object',
-                                name: 'GlobalSlotInterval',
-                                docs: null,
-                                layout: [
-                                  {
-                                    key: 'lower',
-                                    value: { type: 'UInt32' },
-                                    docs: null,
-                                  },
-                                  {
-                                    key: 'upper',
-                                    value: { type: 'UInt32' },
-                                    docs: null,
-                                  },
-                                ],
-                              },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'globalSlotSinceGenesis',
-                            value: {
-                              type: 'option',
-                              optionType: 'implicit',
-                              inner: {
-                                type: 'object',
-                                name: 'GlobalSlotInterval',
-                                docs: null,
-                                layout: [
-                                  {
-                                    key: 'lower',
-                                    value: { type: 'UInt32' },
-                                    docs: null,
-                                  },
-                                  {
-                                    key: 'upper',
-                                    value: { type: 'UInt32' },
-                                    docs: null,
-                                  },
-                                ],
-                              },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'stakingEpochData',
+                            key: 'network',
                             value: {
                               type: 'object',
-                              name: 'EpochDataPrecondition',
+                              name: 'NetworkPrecondition',
                               docs: null,
                               layout: [
                                 {
-                                  key: 'ledger',
+                                  key: 'snarkedLedgerHash',
                                   value: {
-                                    type: 'object',
-                                    name: 'EpochLedgerPrecondition',
-                                    docs: null,
-                                    layout: [
-                                      {
-                                        key: 'hash',
-                                        value: {
-                                          type: 'option',
-                                          optionType: 'flaggedOption',
-                                          inner: { type: 'Field' },
+                                    type: 'option',
+                                    optionType: 'flaggedOption',
+                                    inner: { type: 'Field' },
+                                  },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'timestamp',
+                                  value: {
+                                    type: 'option',
+                                    optionType: 'implicit',
+                                    inner: {
+                                      type: 'object',
+                                      name: 'BlockTimeInterval',
+                                      docs: null,
+                                      layout: [
+                                        {
+                                          key: 'lower',
+                                          value: { type: 'UInt64' },
+                                          docs: null,
                                         },
-                                        docs: null,
-                                      },
-                                      {
-                                        key: 'totalCurrency',
-                                        value: {
-                                          type: 'option',
-                                          optionType: 'implicit',
-                                          inner: {
-                                            type: 'object',
-                                            name: 'CurrencyAmountInterval',
-                                            docs: null,
-                                            layout: [
-                                              {
-                                                key: 'lower',
-                                                value: { type: 'UInt64' },
-                                                docs: null,
-                                              },
-                                              {
-                                                key: 'upper',
-                                                value: { type: 'UInt64' },
-                                                docs: null,
-                                              },
-                                            ],
-                                          },
+                                        {
+                                          key: 'upper',
+                                          value: { type: 'UInt64' },
+                                          docs: null,
                                         },
-                                        docs: null,
-                                      },
-                                    ],
+                                      ],
+                                    },
                                   },
                                   docs: null,
                                 },
                                 {
-                                  key: 'seed',
-                                  value: {
-                                    type: 'option',
-                                    optionType: 'flaggedOption',
-                                    inner: { type: 'Field' },
-                                  },
-                                  docs: null,
-                                },
-                                {
-                                  key: 'startCheckpoint',
-                                  value: {
-                                    type: 'option',
-                                    optionType: 'flaggedOption',
-                                    inner: { type: 'Field' },
-                                  },
-                                  docs: null,
-                                },
-                                {
-                                  key: 'lockCheckpoint',
-                                  value: {
-                                    type: 'option',
-                                    optionType: 'flaggedOption',
-                                    inner: { type: 'Field' },
-                                  },
-                                  docs: null,
-                                },
-                                {
-                                  key: 'epochLength',
+                                  key: 'blockchainLength',
                                   value: {
                                     type: 'option',
                                     optionType: 'implicit',
@@ -1327,91 +1130,8 @@ let jsLayout = {
                                   },
                                   docs: null,
                                 },
-                              ],
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'nextEpochData',
-                            value: {
-                              type: 'object',
-                              name: 'EpochDataPrecondition',
-                              docs: null,
-                              layout: [
                                 {
-                                  key: 'ledger',
-                                  value: {
-                                    type: 'object',
-                                    name: 'EpochLedgerPrecondition',
-                                    docs: null,
-                                    layout: [
-                                      {
-                                        key: 'hash',
-                                        value: {
-                                          type: 'option',
-                                          optionType: 'flaggedOption',
-                                          inner: { type: 'Field' },
-                                        },
-                                        docs: null,
-                                      },
-                                      {
-                                        key: 'totalCurrency',
-                                        value: {
-                                          type: 'option',
-                                          optionType: 'implicit',
-                                          inner: {
-                                            type: 'object',
-                                            name: 'CurrencyAmountInterval',
-                                            docs: null,
-                                            layout: [
-                                              {
-                                                key: 'lower',
-                                                value: { type: 'UInt64' },
-                                                docs: null,
-                                              },
-                                              {
-                                                key: 'upper',
-                                                value: { type: 'UInt64' },
-                                                docs: null,
-                                              },
-                                            ],
-                                          },
-                                        },
-                                        docs: null,
-                                      },
-                                    ],
-                                  },
-                                  docs: null,
-                                },
-                                {
-                                  key: 'seed',
-                                  value: {
-                                    type: 'option',
-                                    optionType: 'flaggedOption',
-                                    inner: { type: 'Field' },
-                                  },
-                                  docs: null,
-                                },
-                                {
-                                  key: 'startCheckpoint',
-                                  value: {
-                                    type: 'option',
-                                    optionType: 'flaggedOption',
-                                    inner: { type: 'Field' },
-                                  },
-                                  docs: null,
-                                },
-                                {
-                                  key: 'lockCheckpoint',
-                                  value: {
-                                    type: 'option',
-                                    optionType: 'flaggedOption',
-                                    inner: { type: 'Field' },
-                                  },
-                                  docs: null,
-                                },
-                                {
-                                  key: 'epochLength',
+                                  key: 'minWindowDensity',
                                   value: {
                                     type: 'option',
                                     optionType: 'implicit',
@@ -1435,116 +1155,407 @@ let jsLayout = {
                                   },
                                   docs: null,
                                 },
+                                {
+                                  key: 'totalCurrency',
+                                  value: {
+                                    type: 'option',
+                                    optionType: 'implicit',
+                                    inner: {
+                                      type: 'object',
+                                      name: 'CurrencyAmountInterval',
+                                      docs: null,
+                                      layout: [
+                                        {
+                                          key: 'lower',
+                                          value: { type: 'UInt64' },
+                                          docs: null,
+                                        },
+                                        {
+                                          key: 'upper',
+                                          value: { type: 'UInt64' },
+                                          docs: null,
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'globalSlotSinceHardFork',
+                                  value: {
+                                    type: 'option',
+                                    optionType: 'implicit',
+                                    inner: {
+                                      type: 'object',
+                                      name: 'GlobalSlotInterval',
+                                      docs: null,
+                                      layout: [
+                                        {
+                                          key: 'lower',
+                                          value: { type: 'UInt32' },
+                                          docs: null,
+                                        },
+                                        {
+                                          key: 'upper',
+                                          value: { type: 'UInt32' },
+                                          docs: null,
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'globalSlotSinceGenesis',
+                                  value: {
+                                    type: 'option',
+                                    optionType: 'implicit',
+                                    inner: {
+                                      type: 'object',
+                                      name: 'GlobalSlotInterval',
+                                      docs: null,
+                                      layout: [
+                                        {
+                                          key: 'lower',
+                                          value: { type: 'UInt32' },
+                                          docs: null,
+                                        },
+                                        {
+                                          key: 'upper',
+                                          value: { type: 'UInt32' },
+                                          docs: null,
+                                        },
+                                      ],
+                                    },
+                                  },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'stakingEpochData',
+                                  value: {
+                                    type: 'object',
+                                    name: 'EpochDataPrecondition',
+                                    docs: null,
+                                    layout: [
+                                      {
+                                        key: 'ledger',
+                                        value: {
+                                          type: 'object',
+                                          name: 'EpochLedgerPrecondition',
+                                          docs: null,
+                                          layout: [
+                                            {
+                                              key: 'hash',
+                                              value: {
+                                                type: 'option',
+                                                optionType: 'flaggedOption',
+                                                inner: { type: 'Field' },
+                                              },
+                                              docs: null,
+                                            },
+                                            {
+                                              key: 'totalCurrency',
+                                              value: {
+                                                type: 'option',
+                                                optionType: 'implicit',
+                                                inner: {
+                                                  type: 'object',
+                                                  name: 'CurrencyAmountInterval',
+                                                  docs: null,
+                                                  layout: [
+                                                    {
+                                                      key: 'lower',
+                                                      value: { type: 'UInt64' },
+                                                      docs: null,
+                                                    },
+                                                    {
+                                                      key: 'upper',
+                                                      value: { type: 'UInt64' },
+                                                      docs: null,
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              docs: null,
+                                            },
+                                          ],
+                                        },
+                                        docs: null,
+                                      },
+                                      {
+                                        key: 'seed',
+                                        value: {
+                                          type: 'option',
+                                          optionType: 'flaggedOption',
+                                          inner: { type: 'Field' },
+                                        },
+                                        docs: null,
+                                      },
+                                      {
+                                        key: 'startCheckpoint',
+                                        value: {
+                                          type: 'option',
+                                          optionType: 'flaggedOption',
+                                          inner: { type: 'Field' },
+                                        },
+                                        docs: null,
+                                      },
+                                      {
+                                        key: 'lockCheckpoint',
+                                        value: {
+                                          type: 'option',
+                                          optionType: 'flaggedOption',
+                                          inner: { type: 'Field' },
+                                        },
+                                        docs: null,
+                                      },
+                                      {
+                                        key: 'epochLength',
+                                        value: {
+                                          type: 'option',
+                                          optionType: 'implicit',
+                                          inner: {
+                                            type: 'object',
+                                            name: 'LengthInterval',
+                                            docs: null,
+                                            layout: [
+                                              {
+                                                key: 'lower',
+                                                value: { type: 'UInt32' },
+                                                docs: null,
+                                              },
+                                              {
+                                                key: 'upper',
+                                                value: { type: 'UInt32' },
+                                                docs: null,
+                                              },
+                                            ],
+                                          },
+                                        },
+                                        docs: null,
+                                      },
+                                    ],
+                                  },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'nextEpochData',
+                                  value: {
+                                    type: 'object',
+                                    name: 'EpochDataPrecondition',
+                                    docs: null,
+                                    layout: [
+                                      {
+                                        key: 'ledger',
+                                        value: {
+                                          type: 'object',
+                                          name: 'EpochLedgerPrecondition',
+                                          docs: null,
+                                          layout: [
+                                            {
+                                              key: 'hash',
+                                              value: {
+                                                type: 'option',
+                                                optionType: 'flaggedOption',
+                                                inner: { type: 'Field' },
+                                              },
+                                              docs: null,
+                                            },
+                                            {
+                                              key: 'totalCurrency',
+                                              value: {
+                                                type: 'option',
+                                                optionType: 'implicit',
+                                                inner: {
+                                                  type: 'object',
+                                                  name: 'CurrencyAmountInterval',
+                                                  docs: null,
+                                                  layout: [
+                                                    {
+                                                      key: 'lower',
+                                                      value: { type: 'UInt64' },
+                                                      docs: null,
+                                                    },
+                                                    {
+                                                      key: 'upper',
+                                                      value: { type: 'UInt64' },
+                                                      docs: null,
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                              docs: null,
+                                            },
+                                          ],
+                                        },
+                                        docs: null,
+                                      },
+                                      {
+                                        key: 'seed',
+                                        value: {
+                                          type: 'option',
+                                          optionType: 'flaggedOption',
+                                          inner: { type: 'Field' },
+                                        },
+                                        docs: null,
+                                      },
+                                      {
+                                        key: 'startCheckpoint',
+                                        value: {
+                                          type: 'option',
+                                          optionType: 'flaggedOption',
+                                          inner: { type: 'Field' },
+                                        },
+                                        docs: null,
+                                      },
+                                      {
+                                        key: 'lockCheckpoint',
+                                        value: {
+                                          type: 'option',
+                                          optionType: 'flaggedOption',
+                                          inner: { type: 'Field' },
+                                        },
+                                        docs: null,
+                                      },
+                                      {
+                                        key: 'epochLength',
+                                        value: {
+                                          type: 'option',
+                                          optionType: 'implicit',
+                                          inner: {
+                                            type: 'object',
+                                            name: 'LengthInterval',
+                                            docs: null,
+                                            layout: [
+                                              {
+                                                key: 'lower',
+                                                value: { type: 'UInt32' },
+                                                docs: null,
+                                              },
+                                              {
+                                                key: 'upper',
+                                                value: { type: 'UInt32' },
+                                                docs: null,
+                                              },
+                                            ],
+                                          },
+                                        },
+                                        docs: null,
+                                      },
+                                    ],
+                                  },
+                                  docs: null,
+                                },
                               ],
                             },
                             docs: null,
                           },
-                        ],
-                      },
-                      docs: null,
-                    },
-                    {
-                      key: 'accountPrecondition',
-                      value: {
-                        type: 'object',
-                        name: 'AccountPrecondition',
-                        docs: null,
-                        layout: [
                           {
-                            key: 'balance',
+                            key: 'account',
                             value: {
-                              type: 'option',
-                              optionType: 'implicit',
-                              inner: {
-                                type: 'object',
-                                name: 'BalanceInterval',
-                                docs: null,
-                                layout: [
-                                  {
-                                    key: 'lower',
-                                    value: { type: 'UInt64' },
-                                    docs: null,
+                              type: 'object',
+                              name: 'AccountPrecondition',
+                              docs: null,
+                              layout: [
+                                {
+                                  key: 'balance',
+                                  value: {
+                                    type: 'option',
+                                    optionType: 'implicit',
+                                    inner: {
+                                      type: 'object',
+                                      name: 'BalanceInterval',
+                                      docs: null,
+                                      layout: [
+                                        {
+                                          key: 'lower',
+                                          value: { type: 'UInt64' },
+                                          docs: null,
+                                        },
+                                        {
+                                          key: 'upper',
+                                          value: { type: 'UInt64' },
+                                          docs: null,
+                                        },
+                                      ],
+                                    },
                                   },
-                                  {
-                                    key: 'upper',
-                                    value: { type: 'UInt64' },
-                                    docs: null,
+                                  docs: null,
+                                },
+                                {
+                                  key: 'nonce',
+                                  value: {
+                                    type: 'option',
+                                    optionType: 'implicit',
+                                    inner: {
+                                      type: 'object',
+                                      name: 'NonceInterval',
+                                      docs: null,
+                                      layout: [
+                                        {
+                                          key: 'lower',
+                                          value: { type: 'UInt32' },
+                                          docs: null,
+                                        },
+                                        {
+                                          key: 'upper',
+                                          value: { type: 'UInt32' },
+                                          docs: null,
+                                        },
+                                      ],
+                                    },
                                   },
-                                ],
-                              },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'nonce',
-                            value: {
-                              type: 'option',
-                              optionType: 'implicit',
-                              inner: {
-                                type: 'object',
-                                name: 'NonceInterval',
-                                docs: null,
-                                layout: [
-                                  {
-                                    key: 'lower',
-                                    value: { type: 'UInt32' },
-                                    docs: null,
+                                  docs: null,
+                                },
+                                {
+                                  key: 'receiptChainHash',
+                                  value: {
+                                    type: 'option',
+                                    optionType: 'flaggedOption',
+                                    inner: { type: 'Field' },
                                   },
-                                  {
-                                    key: 'upper',
-                                    value: { type: 'UInt32' },
-                                    docs: null,
+                                  docs: null,
+                                },
+                                {
+                                  key: 'delegate',
+                                  value: {
+                                    type: 'option',
+                                    optionType: 'flaggedOption',
+                                    inner: { type: 'PublicKey' },
                                   },
-                                ],
-                              },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'receiptChainHash',
-                            value: {
-                              type: 'option',
-                              optionType: 'flaggedOption',
-                              inner: { type: 'Field' },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'delegate',
-                            value: {
-                              type: 'option',
-                              optionType: 'flaggedOption',
-                              inner: { type: 'PublicKey' },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'state',
-                            value: {
-                              type: 'array',
-                              inner: {
-                                type: 'option',
-                                optionType: 'flaggedOption',
-                                inner: { type: 'Field' },
-                              },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'sequenceState',
-                            value: {
-                              type: 'option',
-                              optionType: 'implicit',
-                              inner: { type: 'Field' },
-                            },
-                            docs: null,
-                          },
-                          {
-                            key: 'provedState',
-                            value: {
-                              type: 'option',
-                              optionType: 'flaggedOption',
-                              inner: { type: 'Bool' },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'state',
+                                  value: {
+                                    type: 'array',
+                                    inner: {
+                                      type: 'option',
+                                      optionType: 'flaggedOption',
+                                      inner: { type: 'Field' },
+                                    },
+                                  },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'sequenceState',
+                                  value: {
+                                    type: 'option',
+                                    optionType: 'implicit',
+                                    inner: { type: 'Field' },
+                                  },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'provedState',
+                                  value: {
+                                    type: 'option',
+                                    optionType: 'flaggedOption',
+                                    inner: { type: 'Bool' },
+                                  },
+                                  docs: null,
+                                },
+                              ],
                             },
                             docs: null,
                           },
@@ -1910,252 +1921,55 @@ let jsLayout = {
             { key: 'callData', value: { type: 'Field' }, docs: null },
             { key: 'callDepth', value: { type: 'number' }, docs: null },
             {
-              key: 'protocolStatePrecondition',
+              key: 'preconditions',
               value: {
                 type: 'object',
-                name: 'ProtocolStatePrecondition',
+                name: 'Preconditions',
                 docs: null,
                 layout: [
                   {
-                    key: 'snarkedLedgerHash',
-                    value: {
-                      type: 'option',
-                      optionType: 'flaggedOption',
-                      inner: { type: 'Field' },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'timestamp',
-                    value: {
-                      type: 'option',
-                      optionType: 'implicit',
-                      inner: {
-                        type: 'object',
-                        name: 'BlockTimeInterval',
-                        docs: null,
-                        layout: [
-                          {
-                            key: 'lower',
-                            value: { type: 'UInt64' },
-                            docs: null,
-                          },
-                          {
-                            key: 'upper',
-                            value: { type: 'UInt64' },
-                            docs: null,
-                          },
-                        ],
-                      },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'blockchainLength',
-                    value: {
-                      type: 'option',
-                      optionType: 'implicit',
-                      inner: {
-                        type: 'object',
-                        name: 'LengthInterval',
-                        docs: null,
-                        layout: [
-                          {
-                            key: 'lower',
-                            value: { type: 'UInt32' },
-                            docs: null,
-                          },
-                          {
-                            key: 'upper',
-                            value: { type: 'UInt32' },
-                            docs: null,
-                          },
-                        ],
-                      },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'minWindowDensity',
-                    value: {
-                      type: 'option',
-                      optionType: 'implicit',
-                      inner: {
-                        type: 'object',
-                        name: 'LengthInterval',
-                        docs: null,
-                        layout: [
-                          {
-                            key: 'lower',
-                            value: { type: 'UInt32' },
-                            docs: null,
-                          },
-                          {
-                            key: 'upper',
-                            value: { type: 'UInt32' },
-                            docs: null,
-                          },
-                        ],
-                      },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'totalCurrency',
-                    value: {
-                      type: 'option',
-                      optionType: 'implicit',
-                      inner: {
-                        type: 'object',
-                        name: 'CurrencyAmountInterval',
-                        docs: null,
-                        layout: [
-                          {
-                            key: 'lower',
-                            value: { type: 'UInt64' },
-                            docs: null,
-                          },
-                          {
-                            key: 'upper',
-                            value: { type: 'UInt64' },
-                            docs: null,
-                          },
-                        ],
-                      },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'globalSlotSinceHardFork',
-                    value: {
-                      type: 'option',
-                      optionType: 'implicit',
-                      inner: {
-                        type: 'object',
-                        name: 'GlobalSlotInterval',
-                        docs: null,
-                        layout: [
-                          {
-                            key: 'lower',
-                            value: { type: 'UInt32' },
-                            docs: null,
-                          },
-                          {
-                            key: 'upper',
-                            value: { type: 'UInt32' },
-                            docs: null,
-                          },
-                        ],
-                      },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'globalSlotSinceGenesis',
-                    value: {
-                      type: 'option',
-                      optionType: 'implicit',
-                      inner: {
-                        type: 'object',
-                        name: 'GlobalSlotInterval',
-                        docs: null,
-                        layout: [
-                          {
-                            key: 'lower',
-                            value: { type: 'UInt32' },
-                            docs: null,
-                          },
-                          {
-                            key: 'upper',
-                            value: { type: 'UInt32' },
-                            docs: null,
-                          },
-                        ],
-                      },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'stakingEpochData',
+                    key: 'network',
                     value: {
                       type: 'object',
-                      name: 'EpochDataPrecondition',
+                      name: 'NetworkPrecondition',
                       docs: null,
                       layout: [
                         {
-                          key: 'ledger',
+                          key: 'snarkedLedgerHash',
                           value: {
-                            type: 'object',
-                            name: 'EpochLedgerPrecondition',
-                            docs: null,
-                            layout: [
-                              {
-                                key: 'hash',
-                                value: {
-                                  type: 'option',
-                                  optionType: 'flaggedOption',
-                                  inner: { type: 'Field' },
+                            type: 'option',
+                            optionType: 'flaggedOption',
+                            inner: { type: 'Field' },
+                          },
+                          docs: null,
+                        },
+                        {
+                          key: 'timestamp',
+                          value: {
+                            type: 'option',
+                            optionType: 'implicit',
+                            inner: {
+                              type: 'object',
+                              name: 'BlockTimeInterval',
+                              docs: null,
+                              layout: [
+                                {
+                                  key: 'lower',
+                                  value: { type: 'UInt64' },
+                                  docs: null,
                                 },
-                                docs: null,
-                              },
-                              {
-                                key: 'totalCurrency',
-                                value: {
-                                  type: 'option',
-                                  optionType: 'implicit',
-                                  inner: {
-                                    type: 'object',
-                                    name: 'CurrencyAmountInterval',
-                                    docs: null,
-                                    layout: [
-                                      {
-                                        key: 'lower',
-                                        value: { type: 'UInt64' },
-                                        docs: null,
-                                      },
-                                      {
-                                        key: 'upper',
-                                        value: { type: 'UInt64' },
-                                        docs: null,
-                                      },
-                                    ],
-                                  },
+                                {
+                                  key: 'upper',
+                                  value: { type: 'UInt64' },
+                                  docs: null,
                                 },
-                                docs: null,
-                              },
-                            ],
+                              ],
+                            },
                           },
                           docs: null,
                         },
                         {
-                          key: 'seed',
-                          value: {
-                            type: 'option',
-                            optionType: 'flaggedOption',
-                            inner: { type: 'Field' },
-                          },
-                          docs: null,
-                        },
-                        {
-                          key: 'startCheckpoint',
-                          value: {
-                            type: 'option',
-                            optionType: 'flaggedOption',
-                            inner: { type: 'Field' },
-                          },
-                          docs: null,
-                        },
-                        {
-                          key: 'lockCheckpoint',
-                          value: {
-                            type: 'option',
-                            optionType: 'flaggedOption',
-                            inner: { type: 'Field' },
-                          },
-                          docs: null,
-                        },
-                        {
-                          key: 'epochLength',
+                          key: 'blockchainLength',
                           value: {
                             type: 'option',
                             optionType: 'implicit',
@@ -2179,91 +1993,8 @@ let jsLayout = {
                           },
                           docs: null,
                         },
-                      ],
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'nextEpochData',
-                    value: {
-                      type: 'object',
-                      name: 'EpochDataPrecondition',
-                      docs: null,
-                      layout: [
                         {
-                          key: 'ledger',
-                          value: {
-                            type: 'object',
-                            name: 'EpochLedgerPrecondition',
-                            docs: null,
-                            layout: [
-                              {
-                                key: 'hash',
-                                value: {
-                                  type: 'option',
-                                  optionType: 'flaggedOption',
-                                  inner: { type: 'Field' },
-                                },
-                                docs: null,
-                              },
-                              {
-                                key: 'totalCurrency',
-                                value: {
-                                  type: 'option',
-                                  optionType: 'implicit',
-                                  inner: {
-                                    type: 'object',
-                                    name: 'CurrencyAmountInterval',
-                                    docs: null,
-                                    layout: [
-                                      {
-                                        key: 'lower',
-                                        value: { type: 'UInt64' },
-                                        docs: null,
-                                      },
-                                      {
-                                        key: 'upper',
-                                        value: { type: 'UInt64' },
-                                        docs: null,
-                                      },
-                                    ],
-                                  },
-                                },
-                                docs: null,
-                              },
-                            ],
-                          },
-                          docs: null,
-                        },
-                        {
-                          key: 'seed',
-                          value: {
-                            type: 'option',
-                            optionType: 'flaggedOption',
-                            inner: { type: 'Field' },
-                          },
-                          docs: null,
-                        },
-                        {
-                          key: 'startCheckpoint',
-                          value: {
-                            type: 'option',
-                            optionType: 'flaggedOption',
-                            inner: { type: 'Field' },
-                          },
-                          docs: null,
-                        },
-                        {
-                          key: 'lockCheckpoint',
-                          value: {
-                            type: 'option',
-                            optionType: 'flaggedOption',
-                            inner: { type: 'Field' },
-                          },
-                          docs: null,
-                        },
-                        {
-                          key: 'epochLength',
+                          key: 'minWindowDensity',
                           value: {
                             type: 'option',
                             optionType: 'implicit',
@@ -2287,116 +2018,407 @@ let jsLayout = {
                           },
                           docs: null,
                         },
+                        {
+                          key: 'totalCurrency',
+                          value: {
+                            type: 'option',
+                            optionType: 'implicit',
+                            inner: {
+                              type: 'object',
+                              name: 'CurrencyAmountInterval',
+                              docs: null,
+                              layout: [
+                                {
+                                  key: 'lower',
+                                  value: { type: 'UInt64' },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'upper',
+                                  value: { type: 'UInt64' },
+                                  docs: null,
+                                },
+                              ],
+                            },
+                          },
+                          docs: null,
+                        },
+                        {
+                          key: 'globalSlotSinceHardFork',
+                          value: {
+                            type: 'option',
+                            optionType: 'implicit',
+                            inner: {
+                              type: 'object',
+                              name: 'GlobalSlotInterval',
+                              docs: null,
+                              layout: [
+                                {
+                                  key: 'lower',
+                                  value: { type: 'UInt32' },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'upper',
+                                  value: { type: 'UInt32' },
+                                  docs: null,
+                                },
+                              ],
+                            },
+                          },
+                          docs: null,
+                        },
+                        {
+                          key: 'globalSlotSinceGenesis',
+                          value: {
+                            type: 'option',
+                            optionType: 'implicit',
+                            inner: {
+                              type: 'object',
+                              name: 'GlobalSlotInterval',
+                              docs: null,
+                              layout: [
+                                {
+                                  key: 'lower',
+                                  value: { type: 'UInt32' },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'upper',
+                                  value: { type: 'UInt32' },
+                                  docs: null,
+                                },
+                              ],
+                            },
+                          },
+                          docs: null,
+                        },
+                        {
+                          key: 'stakingEpochData',
+                          value: {
+                            type: 'object',
+                            name: 'EpochDataPrecondition',
+                            docs: null,
+                            layout: [
+                              {
+                                key: 'ledger',
+                                value: {
+                                  type: 'object',
+                                  name: 'EpochLedgerPrecondition',
+                                  docs: null,
+                                  layout: [
+                                    {
+                                      key: 'hash',
+                                      value: {
+                                        type: 'option',
+                                        optionType: 'flaggedOption',
+                                        inner: { type: 'Field' },
+                                      },
+                                      docs: null,
+                                    },
+                                    {
+                                      key: 'totalCurrency',
+                                      value: {
+                                        type: 'option',
+                                        optionType: 'implicit',
+                                        inner: {
+                                          type: 'object',
+                                          name: 'CurrencyAmountInterval',
+                                          docs: null,
+                                          layout: [
+                                            {
+                                              key: 'lower',
+                                              value: { type: 'UInt64' },
+                                              docs: null,
+                                            },
+                                            {
+                                              key: 'upper',
+                                              value: { type: 'UInt64' },
+                                              docs: null,
+                                            },
+                                          ],
+                                        },
+                                      },
+                                      docs: null,
+                                    },
+                                  ],
+                                },
+                                docs: null,
+                              },
+                              {
+                                key: 'seed',
+                                value: {
+                                  type: 'option',
+                                  optionType: 'flaggedOption',
+                                  inner: { type: 'Field' },
+                                },
+                                docs: null,
+                              },
+                              {
+                                key: 'startCheckpoint',
+                                value: {
+                                  type: 'option',
+                                  optionType: 'flaggedOption',
+                                  inner: { type: 'Field' },
+                                },
+                                docs: null,
+                              },
+                              {
+                                key: 'lockCheckpoint',
+                                value: {
+                                  type: 'option',
+                                  optionType: 'flaggedOption',
+                                  inner: { type: 'Field' },
+                                },
+                                docs: null,
+                              },
+                              {
+                                key: 'epochLength',
+                                value: {
+                                  type: 'option',
+                                  optionType: 'implicit',
+                                  inner: {
+                                    type: 'object',
+                                    name: 'LengthInterval',
+                                    docs: null,
+                                    layout: [
+                                      {
+                                        key: 'lower',
+                                        value: { type: 'UInt32' },
+                                        docs: null,
+                                      },
+                                      {
+                                        key: 'upper',
+                                        value: { type: 'UInt32' },
+                                        docs: null,
+                                      },
+                                    ],
+                                  },
+                                },
+                                docs: null,
+                              },
+                            ],
+                          },
+                          docs: null,
+                        },
+                        {
+                          key: 'nextEpochData',
+                          value: {
+                            type: 'object',
+                            name: 'EpochDataPrecondition',
+                            docs: null,
+                            layout: [
+                              {
+                                key: 'ledger',
+                                value: {
+                                  type: 'object',
+                                  name: 'EpochLedgerPrecondition',
+                                  docs: null,
+                                  layout: [
+                                    {
+                                      key: 'hash',
+                                      value: {
+                                        type: 'option',
+                                        optionType: 'flaggedOption',
+                                        inner: { type: 'Field' },
+                                      },
+                                      docs: null,
+                                    },
+                                    {
+                                      key: 'totalCurrency',
+                                      value: {
+                                        type: 'option',
+                                        optionType: 'implicit',
+                                        inner: {
+                                          type: 'object',
+                                          name: 'CurrencyAmountInterval',
+                                          docs: null,
+                                          layout: [
+                                            {
+                                              key: 'lower',
+                                              value: { type: 'UInt64' },
+                                              docs: null,
+                                            },
+                                            {
+                                              key: 'upper',
+                                              value: { type: 'UInt64' },
+                                              docs: null,
+                                            },
+                                          ],
+                                        },
+                                      },
+                                      docs: null,
+                                    },
+                                  ],
+                                },
+                                docs: null,
+                              },
+                              {
+                                key: 'seed',
+                                value: {
+                                  type: 'option',
+                                  optionType: 'flaggedOption',
+                                  inner: { type: 'Field' },
+                                },
+                                docs: null,
+                              },
+                              {
+                                key: 'startCheckpoint',
+                                value: {
+                                  type: 'option',
+                                  optionType: 'flaggedOption',
+                                  inner: { type: 'Field' },
+                                },
+                                docs: null,
+                              },
+                              {
+                                key: 'lockCheckpoint',
+                                value: {
+                                  type: 'option',
+                                  optionType: 'flaggedOption',
+                                  inner: { type: 'Field' },
+                                },
+                                docs: null,
+                              },
+                              {
+                                key: 'epochLength',
+                                value: {
+                                  type: 'option',
+                                  optionType: 'implicit',
+                                  inner: {
+                                    type: 'object',
+                                    name: 'LengthInterval',
+                                    docs: null,
+                                    layout: [
+                                      {
+                                        key: 'lower',
+                                        value: { type: 'UInt32' },
+                                        docs: null,
+                                      },
+                                      {
+                                        key: 'upper',
+                                        value: { type: 'UInt32' },
+                                        docs: null,
+                                      },
+                                    ],
+                                  },
+                                },
+                                docs: null,
+                              },
+                            ],
+                          },
+                          docs: null,
+                        },
                       ],
                     },
                     docs: null,
                   },
-                ],
-              },
-              docs: null,
-            },
-            {
-              key: 'accountPrecondition',
-              value: {
-                type: 'object',
-                name: 'AccountPrecondition',
-                docs: null,
-                layout: [
                   {
-                    key: 'balance',
+                    key: 'account',
                     value: {
-                      type: 'option',
-                      optionType: 'implicit',
-                      inner: {
-                        type: 'object',
-                        name: 'BalanceInterval',
-                        docs: null,
-                        layout: [
-                          {
-                            key: 'lower',
-                            value: { type: 'UInt64' },
-                            docs: null,
+                      type: 'object',
+                      name: 'AccountPrecondition',
+                      docs: null,
+                      layout: [
+                        {
+                          key: 'balance',
+                          value: {
+                            type: 'option',
+                            optionType: 'implicit',
+                            inner: {
+                              type: 'object',
+                              name: 'BalanceInterval',
+                              docs: null,
+                              layout: [
+                                {
+                                  key: 'lower',
+                                  value: { type: 'UInt64' },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'upper',
+                                  value: { type: 'UInt64' },
+                                  docs: null,
+                                },
+                              ],
+                            },
                           },
-                          {
-                            key: 'upper',
-                            value: { type: 'UInt64' },
-                            docs: null,
+                          docs: null,
+                        },
+                        {
+                          key: 'nonce',
+                          value: {
+                            type: 'option',
+                            optionType: 'implicit',
+                            inner: {
+                              type: 'object',
+                              name: 'NonceInterval',
+                              docs: null,
+                              layout: [
+                                {
+                                  key: 'lower',
+                                  value: { type: 'UInt32' },
+                                  docs: null,
+                                },
+                                {
+                                  key: 'upper',
+                                  value: { type: 'UInt32' },
+                                  docs: null,
+                                },
+                              ],
+                            },
                           },
-                        ],
-                      },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'nonce',
-                    value: {
-                      type: 'option',
-                      optionType: 'implicit',
-                      inner: {
-                        type: 'object',
-                        name: 'NonceInterval',
-                        docs: null,
-                        layout: [
-                          {
-                            key: 'lower',
-                            value: { type: 'UInt32' },
-                            docs: null,
+                          docs: null,
+                        },
+                        {
+                          key: 'receiptChainHash',
+                          value: {
+                            type: 'option',
+                            optionType: 'flaggedOption',
+                            inner: { type: 'Field' },
                           },
-                          {
-                            key: 'upper',
-                            value: { type: 'UInt32' },
-                            docs: null,
+                          docs: null,
+                        },
+                        {
+                          key: 'delegate',
+                          value: {
+                            type: 'option',
+                            optionType: 'flaggedOption',
+                            inner: { type: 'PublicKey' },
                           },
-                        ],
-                      },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'receiptChainHash',
-                    value: {
-                      type: 'option',
-                      optionType: 'flaggedOption',
-                      inner: { type: 'Field' },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'delegate',
-                    value: {
-                      type: 'option',
-                      optionType: 'flaggedOption',
-                      inner: { type: 'PublicKey' },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'state',
-                    value: {
-                      type: 'array',
-                      inner: {
-                        type: 'option',
-                        optionType: 'flaggedOption',
-                        inner: { type: 'Field' },
-                      },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'sequenceState',
-                    value: {
-                      type: 'option',
-                      optionType: 'implicit',
-                      inner: { type: 'Field' },
-                    },
-                    docs: null,
-                  },
-                  {
-                    key: 'provedState',
-                    value: {
-                      type: 'option',
-                      optionType: 'flaggedOption',
-                      inner: { type: 'Bool' },
+                          docs: null,
+                        },
+                        {
+                          key: 'state',
+                          value: {
+                            type: 'array',
+                            inner: {
+                              type: 'option',
+                              optionType: 'flaggedOption',
+                              inner: { type: 'Field' },
+                            },
+                          },
+                          docs: null,
+                        },
+                        {
+                          key: 'sequenceState',
+                          value: {
+                            type: 'option',
+                            optionType: 'implicit',
+                            inner: { type: 'Field' },
+                          },
+                          docs: null,
+                        },
+                        {
+                          key: 'provedState',
+                          value: {
+                            type: 'option',
+                            optionType: 'flaggedOption',
+                            inner: { type: 'Bool' },
+                          },
+                          docs: null,
+                        },
+                      ],
                     },
                     docs: null,
                   },

--- a/src/snarky/gen/parties-json.ts
+++ b/src/snarky/gen/parties-json.ts
@@ -52,7 +52,7 @@ type Parties = {
       fee: UInt64;
       events: Field[][];
       sequenceEvents: Field[][];
-      protocolStatePrecondition: {
+      networkPrecondition: {
         snarkedLedgerHash: Field | null;
         timestamp: {
           lower: UInt64;
@@ -159,7 +159,139 @@ type Parties = {
       sequenceEvents: Field[][];
       callData: Field;
       callDepth: number;
-      protocolStatePrecondition: {
+      preconditions: {
+        network: {
+          snarkedLedgerHash: Field | null;
+          timestamp: {
+            lower: UInt64;
+            upper: UInt64;
+          } | null;
+          blockchainLength: {
+            lower: UInt32;
+            upper: UInt32;
+          } | null;
+          minWindowDensity: {
+            lower: UInt32;
+            upper: UInt32;
+          } | null;
+          totalCurrency: {
+            lower: UInt64;
+            upper: UInt64;
+          } | null;
+          globalSlotSinceHardFork: {
+            lower: UInt32;
+            upper: UInt32;
+          } | null;
+          globalSlotSinceGenesis: {
+            lower: UInt32;
+            upper: UInt32;
+          } | null;
+          stakingEpochData: {
+            ledger: {
+              hash: Field | null;
+              totalCurrency: {
+                lower: UInt64;
+                upper: UInt64;
+              } | null;
+            };
+            seed: Field | null;
+            startCheckpoint: Field | null;
+            lockCheckpoint: Field | null;
+            epochLength: {
+              lower: UInt32;
+              upper: UInt32;
+            } | null;
+          };
+          nextEpochData: {
+            ledger: {
+              hash: Field | null;
+              totalCurrency: {
+                lower: UInt64;
+                upper: UInt64;
+              } | null;
+            };
+            seed: Field | null;
+            startCheckpoint: Field | null;
+            lockCheckpoint: Field | null;
+            epochLength: {
+              lower: UInt32;
+              upper: UInt32;
+            } | null;
+          };
+        };
+        account: {
+          balance: {
+            lower: UInt64;
+            upper: UInt64;
+          } | null;
+          nonce: {
+            lower: UInt32;
+            upper: UInt32;
+          } | null;
+          receiptChainHash: Field | null;
+          delegate: PublicKey | null;
+          state: (Field | null)[];
+          sequenceState: Field | null;
+          provedState: Bool | null;
+        };
+      };
+      useFullCommitment: Bool;
+      caller: TokenId;
+    };
+    authorization: {
+      proof: string | null;
+      signature: string | null;
+    };
+  }[];
+  memo: string;
+};
+
+type Party = {
+  body: {
+    publicKey: PublicKey;
+    tokenId: TokenId;
+    update: {
+      appState: (Field | null)[];
+      delegate: PublicKey | null;
+      verificationKey: {
+        data: string;
+        hash: Field;
+      } | null;
+      permissions: {
+        editState: AuthRequired;
+        send: AuthRequired;
+        receive: AuthRequired;
+        setDelegate: AuthRequired;
+        setPermissions: AuthRequired;
+        setVerificationKey: AuthRequired;
+        setZkappUri: AuthRequired;
+        editSequenceState: AuthRequired;
+        setTokenSymbol: AuthRequired;
+        incrementNonce: AuthRequired;
+        setVotingFor: AuthRequired;
+      } | null;
+      zkappUri: string | null;
+      tokenSymbol: string | null;
+      timing: {
+        initialMinimumBalance: UInt64;
+        cliffTime: UInt32;
+        cliffAmount: UInt64;
+        vestingPeriod: UInt32;
+        vestingIncrement: UInt64;
+      } | null;
+      votingFor: Field | null;
+    };
+    balanceChange: {
+      magnitude: UInt64;
+      sgn: Sign;
+    };
+    incrementNonce: Bool;
+    events: Field[][];
+    sequenceEvents: Field[][];
+    callData: Field;
+    callDepth: number;
+    preconditions: {
+      network: {
         snarkedLedgerHash: Field | null;
         timestamp: {
           lower: UInt64;
@@ -218,7 +350,7 @@ type Parties = {
           } | null;
         };
       };
-      accountPrecondition: {
+      account: {
         balance: {
           lower: UInt64;
           upper: UInt64;
@@ -233,134 +365,6 @@ type Parties = {
         sequenceState: Field | null;
         provedState: Bool | null;
       };
-      useFullCommitment: Bool;
-      caller: TokenId;
-    };
-    authorization: {
-      proof: string | null;
-      signature: string | null;
-    };
-  }[];
-  memo: string;
-};
-
-type Party = {
-  body: {
-    publicKey: PublicKey;
-    tokenId: TokenId;
-    update: {
-      appState: (Field | null)[];
-      delegate: PublicKey | null;
-      verificationKey: {
-        data: string;
-        hash: Field;
-      } | null;
-      permissions: {
-        editState: AuthRequired;
-        send: AuthRequired;
-        receive: AuthRequired;
-        setDelegate: AuthRequired;
-        setPermissions: AuthRequired;
-        setVerificationKey: AuthRequired;
-        setZkappUri: AuthRequired;
-        editSequenceState: AuthRequired;
-        setTokenSymbol: AuthRequired;
-        incrementNonce: AuthRequired;
-        setVotingFor: AuthRequired;
-      } | null;
-      zkappUri: string | null;
-      tokenSymbol: string | null;
-      timing: {
-        initialMinimumBalance: UInt64;
-        cliffTime: UInt32;
-        cliffAmount: UInt64;
-        vestingPeriod: UInt32;
-        vestingIncrement: UInt64;
-      } | null;
-      votingFor: Field | null;
-    };
-    balanceChange: {
-      magnitude: UInt64;
-      sgn: Sign;
-    };
-    incrementNonce: Bool;
-    events: Field[][];
-    sequenceEvents: Field[][];
-    callData: Field;
-    callDepth: number;
-    protocolStatePrecondition: {
-      snarkedLedgerHash: Field | null;
-      timestamp: {
-        lower: UInt64;
-        upper: UInt64;
-      } | null;
-      blockchainLength: {
-        lower: UInt32;
-        upper: UInt32;
-      } | null;
-      minWindowDensity: {
-        lower: UInt32;
-        upper: UInt32;
-      } | null;
-      totalCurrency: {
-        lower: UInt64;
-        upper: UInt64;
-      } | null;
-      globalSlotSinceHardFork: {
-        lower: UInt32;
-        upper: UInt32;
-      } | null;
-      globalSlotSinceGenesis: {
-        lower: UInt32;
-        upper: UInt32;
-      } | null;
-      stakingEpochData: {
-        ledger: {
-          hash: Field | null;
-          totalCurrency: {
-            lower: UInt64;
-            upper: UInt64;
-          } | null;
-        };
-        seed: Field | null;
-        startCheckpoint: Field | null;
-        lockCheckpoint: Field | null;
-        epochLength: {
-          lower: UInt32;
-          upper: UInt32;
-        } | null;
-      };
-      nextEpochData: {
-        ledger: {
-          hash: Field | null;
-          totalCurrency: {
-            lower: UInt64;
-            upper: UInt64;
-          } | null;
-        };
-        seed: Field | null;
-        startCheckpoint: Field | null;
-        lockCheckpoint: Field | null;
-        epochLength: {
-          lower: UInt32;
-          upper: UInt32;
-        } | null;
-      };
-    };
-    accountPrecondition: {
-      balance: {
-        lower: UInt64;
-        upper: UInt64;
-      } | null;
-      nonce: {
-        lower: UInt32;
-        upper: UInt32;
-      } | null;
-      receiptChainHash: Field | null;
-      delegate: PublicKey | null;
-      state: (Field | null)[];
-      sequenceState: Field | null;
-      provedState: Bool | null;
     };
     useFullCommitment: Bool;
     caller: TokenId;

--- a/src/snarky/gen/parties.ts
+++ b/src/snarky/gen/parties.ts
@@ -111,7 +111,7 @@ type Parties = {
         data: Field[][];
         hash: Field;
       };
-      protocolStatePrecondition: {
+      networkPrecondition: {
         snarkedLedgerHash: { isSome: Bool; value: Field };
         timestamp: {
           lower: UInt64;
@@ -245,79 +245,81 @@ type Parties = {
       };
       callData: Field;
       callDepth: number;
-      protocolStatePrecondition: {
-        snarkedLedgerHash: { isSome: Bool; value: Field };
-        timestamp: {
-          lower: UInt64;
-          upper: UInt64;
-        };
-        blockchainLength: {
-          lower: UInt32;
-          upper: UInt32;
-        };
-        minWindowDensity: {
-          lower: UInt32;
-          upper: UInt32;
-        };
-        totalCurrency: {
-          lower: UInt64;
-          upper: UInt64;
-        };
-        globalSlotSinceHardFork: {
-          lower: UInt32;
-          upper: UInt32;
-        };
-        globalSlotSinceGenesis: {
-          lower: UInt32;
-          upper: UInt32;
-        };
-        stakingEpochData: {
-          ledger: {
-            hash: { isSome: Bool; value: Field };
-            totalCurrency: {
-              lower: UInt64;
-              upper: UInt64;
-            };
+      preconditions: {
+        network: {
+          snarkedLedgerHash: { isSome: Bool; value: Field };
+          timestamp: {
+            lower: UInt64;
+            upper: UInt64;
           };
-          seed: { isSome: Bool; value: Field };
-          startCheckpoint: { isSome: Bool; value: Field };
-          lockCheckpoint: { isSome: Bool; value: Field };
-          epochLength: {
+          blockchainLength: {
             lower: UInt32;
             upper: UInt32;
           };
-        };
-        nextEpochData: {
-          ledger: {
-            hash: { isSome: Bool; value: Field };
-            totalCurrency: {
-              lower: UInt64;
-              upper: UInt64;
-            };
-          };
-          seed: { isSome: Bool; value: Field };
-          startCheckpoint: { isSome: Bool; value: Field };
-          lockCheckpoint: { isSome: Bool; value: Field };
-          epochLength: {
+          minWindowDensity: {
             lower: UInt32;
             upper: UInt32;
           };
+          totalCurrency: {
+            lower: UInt64;
+            upper: UInt64;
+          };
+          globalSlotSinceHardFork: {
+            lower: UInt32;
+            upper: UInt32;
+          };
+          globalSlotSinceGenesis: {
+            lower: UInt32;
+            upper: UInt32;
+          };
+          stakingEpochData: {
+            ledger: {
+              hash: { isSome: Bool; value: Field };
+              totalCurrency: {
+                lower: UInt64;
+                upper: UInt64;
+              };
+            };
+            seed: { isSome: Bool; value: Field };
+            startCheckpoint: { isSome: Bool; value: Field };
+            lockCheckpoint: { isSome: Bool; value: Field };
+            epochLength: {
+              lower: UInt32;
+              upper: UInt32;
+            };
+          };
+          nextEpochData: {
+            ledger: {
+              hash: { isSome: Bool; value: Field };
+              totalCurrency: {
+                lower: UInt64;
+                upper: UInt64;
+              };
+            };
+            seed: { isSome: Bool; value: Field };
+            startCheckpoint: { isSome: Bool; value: Field };
+            lockCheckpoint: { isSome: Bool; value: Field };
+            epochLength: {
+              lower: UInt32;
+              upper: UInt32;
+            };
+          };
         };
-      };
-      accountPrecondition: {
-        balance: {
-          lower: UInt64;
-          upper: UInt64;
+        account: {
+          balance: {
+            lower: UInt64;
+            upper: UInt64;
+          };
+          nonce: {
+            lower: UInt32;
+            upper: UInt32;
+          };
+          receiptChainHash: { isSome: Bool; value: Field };
+          delegate: { isSome: Bool; value: PublicKey };
+          state: { isSome: Bool; value: Field }[];
+          sequenceState: Field;
+          provedState: { isSome: Bool; value: Bool };
         };
-        nonce: {
-          lower: UInt32;
-          upper: UInt32;
-        };
-        receiptChainHash: { isSome: Bool; value: Field };
-        delegate: { isSome: Bool; value: PublicKey };
-        state: { isSome: Bool; value: Field }[];
-        sequenceState: Field;
-        provedState: { isSome: Bool; value: Bool };
       };
       useFullCommitment: Bool;
       caller: TokenId;
@@ -410,79 +412,81 @@ type Party = {
     };
     callData: Field;
     callDepth: number;
-    protocolStatePrecondition: {
-      snarkedLedgerHash: { isSome: Bool; value: Field };
-      timestamp: {
-        lower: UInt64;
-        upper: UInt64;
-      };
-      blockchainLength: {
-        lower: UInt32;
-        upper: UInt32;
-      };
-      minWindowDensity: {
-        lower: UInt32;
-        upper: UInt32;
-      };
-      totalCurrency: {
-        lower: UInt64;
-        upper: UInt64;
-      };
-      globalSlotSinceHardFork: {
-        lower: UInt32;
-        upper: UInt32;
-      };
-      globalSlotSinceGenesis: {
-        lower: UInt32;
-        upper: UInt32;
-      };
-      stakingEpochData: {
-        ledger: {
-          hash: { isSome: Bool; value: Field };
-          totalCurrency: {
-            lower: UInt64;
-            upper: UInt64;
-          };
+    preconditions: {
+      network: {
+        snarkedLedgerHash: { isSome: Bool; value: Field };
+        timestamp: {
+          lower: UInt64;
+          upper: UInt64;
         };
-        seed: { isSome: Bool; value: Field };
-        startCheckpoint: { isSome: Bool; value: Field };
-        lockCheckpoint: { isSome: Bool; value: Field };
-        epochLength: {
+        blockchainLength: {
           lower: UInt32;
           upper: UInt32;
         };
-      };
-      nextEpochData: {
-        ledger: {
-          hash: { isSome: Bool; value: Field };
-          totalCurrency: {
-            lower: UInt64;
-            upper: UInt64;
-          };
-        };
-        seed: { isSome: Bool; value: Field };
-        startCheckpoint: { isSome: Bool; value: Field };
-        lockCheckpoint: { isSome: Bool; value: Field };
-        epochLength: {
+        minWindowDensity: {
           lower: UInt32;
           upper: UInt32;
         };
+        totalCurrency: {
+          lower: UInt64;
+          upper: UInt64;
+        };
+        globalSlotSinceHardFork: {
+          lower: UInt32;
+          upper: UInt32;
+        };
+        globalSlotSinceGenesis: {
+          lower: UInt32;
+          upper: UInt32;
+        };
+        stakingEpochData: {
+          ledger: {
+            hash: { isSome: Bool; value: Field };
+            totalCurrency: {
+              lower: UInt64;
+              upper: UInt64;
+            };
+          };
+          seed: { isSome: Bool; value: Field };
+          startCheckpoint: { isSome: Bool; value: Field };
+          lockCheckpoint: { isSome: Bool; value: Field };
+          epochLength: {
+            lower: UInt32;
+            upper: UInt32;
+          };
+        };
+        nextEpochData: {
+          ledger: {
+            hash: { isSome: Bool; value: Field };
+            totalCurrency: {
+              lower: UInt64;
+              upper: UInt64;
+            };
+          };
+          seed: { isSome: Bool; value: Field };
+          startCheckpoint: { isSome: Bool; value: Field };
+          lockCheckpoint: { isSome: Bool; value: Field };
+          epochLength: {
+            lower: UInt32;
+            upper: UInt32;
+          };
+        };
       };
-    };
-    accountPrecondition: {
-      balance: {
-        lower: UInt64;
-        upper: UInt64;
+      account: {
+        balance: {
+          lower: UInt64;
+          upper: UInt64;
+        };
+        nonce: {
+          lower: UInt32;
+          upper: UInt32;
+        };
+        receiptChainHash: { isSome: Bool; value: Field };
+        delegate: { isSome: Bool; value: PublicKey };
+        state: { isSome: Bool; value: Field }[];
+        sequenceState: Field;
+        provedState: { isSome: Bool; value: Bool };
       };
-      nonce: {
-        lower: UInt32;
-        upper: UInt32;
-      };
-      receiptChainHash: { isSome: Bool; value: Field };
-      delegate: { isSome: Bool; value: PublicKey };
-      state: { isSome: Bool; value: Field }[];
-      sequenceState: Field;
-      provedState: { isSome: Bool; value: Bool };
     };
     useFullCommitment: Bool;
     caller: TokenId;

--- a/src/snarky/index.js
+++ b/src/snarky/index.js
@@ -15,6 +15,7 @@ export {
   Pickles,
 };
 export * as Types from './gen/parties';
+export { jsLayout } from './gen/js-layout';
 
 let isReadyBoolean = false;
 let isReady = snarky_ready.then(() => (isReadyBoolean = true));

--- a/src/snarky/parties-leaves.ts
+++ b/src/snarky/parties-leaves.ts
@@ -12,8 +12,8 @@ export {
 
 export { toJson, toJsonLeafTypes, toFields, toFieldsLeafTypes };
 
-type UInt64 = { value: Field };
-type UInt32 = { value: Field };
+type UInt64 = { value: Field; type: 'UInt64' };
+type UInt32 = { value: Field; type: 'UInt32' };
 type Sign = Field; // constrained to +-1
 type PublicKey = { g: Group };
 type AuthRequired = {

--- a/src/snarky/snarky-class-spec.json
+++ b/src/snarky/snarky-class-spec.json
@@ -120,6 +120,14 @@
     "name": "Bool",
     "props": [
       {
+        "name": "true",
+        "type": "object"
+      },
+      {
+        "name": "false",
+        "type": "object"
+      },
+      {
         "name": "toField",
         "type": "function"
       },

--- a/src/snarky/wrapper.d.ts
+++ b/src/snarky/wrapper.d.ts
@@ -1,7 +1,13 @@
 import * as wasm from '../node_bindings/plonk_wasm';
 
-export { WasmModule, getWasm };
+export { WasmModule, getWasm, getSnarky, snarky_ready, shutdown };
 
 type WasmModule = typeof wasm;
 
 declare function getWasm(): WasmModule;
+
+declare function getSnarky(): any;
+
+declare let snarky_ready: Promise<undefined>;
+
+declare function shutdown(): Promise<undefined>;


### PR DESCRIPTION
**For the purposes of this exercise please do not comment directly on this PR** (as we want to use this for several candidates)!

You may use the PR to view the diff nicely, but please instead prepare your feedback in a markdown file `feedback.md` where you can comment on a line of code like: 

```
src/examples/simple_zkapp.ts:84

I thought this line of code was particularly hard to understand. Could you instead do X or Y?

src/mina.ts:100

This is line 100 of mina.ts
```

You may also include comments that are not attached to particular file:lines at the top or bottom of your `feedback.md` file.

Thank you!

----

* Adds precondition feature to SnarkyJS
* Includes an example @ src/examples/simple_zkapp.ts
* Adds a method for checking deep equality of circuit values

Explanation of the precondition feature below:

We consolidate account / network preconditions under a single field, `this.account` and `this.network`. Using account / network fields looks like this:

```ts
let myBalance = this.account.balance.get();
// should be equal to my actual balance
this.account.balance.assertEquals(myBalance);
// ... doing arbitrary computations with the balance

let chainLength = this.network.blockchainLength.get();
// should be not more than the current length + 5
this.network.blockchainLength.assertBetween(chainLength, chainLength.add(5));
```

`this.account.balance.get()` does the following: It fetches the balance from chain and creates a variable with that value in it. It does NOT link it to the current balance in the snark circuit. Instead, explicit `assertEquals` or `assertBetween` is necessary to create that link.

To make this not a footgun, we throw an error if the user doesn't add any explicit precondition on the field. The error is thrown when compiling, proving, or running the smart contract method in any other way. Example:

```ts
@method payout(caller: PublicKey) {
  let balance = this.account.balance.get();
  this.transfer(balance.div(10), caller); // tentative API to send money from the zkapp account
}
// ...

MyContract.compile(zkappAddress); // throws an error!
```

Running this would throw:

```
Error: You used `this.account.balance.get()` without adding a precondition that links it to the actual balance.
Consider adding this line to your code:
this.account.balance.assertEquals(this.account.balance.get());
You can also add more flexible preconditions with `this.account.balance.assertBetween`.
    at /home/gregor/my-zkapp/node_modules/snarkyjs/dist/server/index.js:5039:145
    ...
```

The developer would hopefully read the error message and modify their code like this .. which would fix the error, and teach them about preconditions at the same time.

```ts
@method payout(caller: PublicKey) {
  let balance = this.account.balance.get();
  this.account.balance.assertEquals(balance);
  this.transfer(balance.div(10), caller); // tentative API to send money from the zkapp account
}
```